### PR TITLE
feat(peach): Implement Peach Payments provider

### DIFF
--- a/.github/instructions/peach-payments.instructions.md
+++ b/.github/instructions/peach-payments.instructions.md
@@ -1,0 +1,212 @@
+---
+description: "Use when implementing, extending, or refactoring the Peach Payments integration, including provider calls, webhook handling, config, provider registration, and tests."
+name: "Peach Payments Integration"
+applyTo:
+  - "src/providers/peach/**"
+  - "src/domain/provider.interface.ts"
+  - "src/app.ts"
+  - "src/routes/webhook.routes.ts"
+  - "src/config/env.ts"
+  - "tests/**/*peach*.test.ts"
+---
+
+# Peach Payments Integration
+
+- Keep Peach-specific request building, response mapping, webhook parsing, and signature verification in `src/providers/peach/*`.
+- Use `src/infrastructure/http.client.ts` for Peach API calls. Do not call `fetch`, `axios`, or provider endpoints directly from controllers or services.
+- Preserve the existing orchestrator split: controllers handle HTTP, services orchestrate, and the Peach provider handles external API details.
+- Reuse `src/providers/shared/base.provider.ts` response normalization. Preserve compatibility fields such as `checkoutUrl`, `redirectLink`, `redirectUrl`, and `inlineRedirect` when Peach needs redirects.
+- If Peach needs multiple transaction steps, keep them in separate Peach modules by operation instead of one large provider file.
+- If Peach requires new provider capabilities or request fields, update `src/domain/provider.interface.ts` and the relevant Zod schemas before wiring controller changes.
+- Keep Peach registration and runtime wiring aligned across `src/app.ts`, `src/config/env.ts`, webhook routes, and provider exports so the integration is not partially added.
+- Map Peach external statuses and webhook events into internal `PaymentStatus` values consistently and preserve existing error response shapes.
+- Add or update automated tests for Peach provider behavior and any affected payment or webhook flows. If request or response shapes change, update integration tests and `README.md` in the same change.
+
+Peach Payments — Integration Plan (Phases 2–7)
+
+Phase 2 — Understand the payment flow
+Payment Page is built on Hosted Checkout. The end-to-end flow for every payment method works like this:
+
+Your backend builds a signed payment request
+Customer is redirected to Peach's hosted payment page
+Customer selects a payment method and completes payment
+Peach redirects back to your shopperResultUrl
+Peach also POSTs a webhook to your notificationUrl
+Your backend queries the transaction status to confirm the result before fulfilling the order
+
+Checkout payment flow overview:
+https://developer.peachpayments.com/docs/checkout-payment-flow
+Payments API flow detail:
+https://developer.peachpayments.com/docs/payments-api-flows
+All supported payment methods:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Phase 3 — Authentication & signature generation
+Every payment request requires an HMAC SHA256 signature. Here's how it works:
+
+Take all your request parameters and sort them alphabetically by key
+Concatenate them as key1value1key2value2... (no separators)
+Sign that string using your secret token with HMAC SHA256
+Include the result as the signature field in your request
+
+Every request also needs a unique nonce — any unique string you generate per request. The signature changes every time because the nonce changes.
+Verify your signature logic during development using this tool:
+https://www.freeformatter.com/hmac-generator.html
+Hosted Checkout authentication & authorisation:
+https://developer.peachpayments.com/docs/checkout-authentication
+Node.js sample calls — Postman collection:
+https://www.postman.com/peachpayments/peach-payments-public-workspace/request/yblmbqd/payments-public?action=share&creator=20323380&ctx=documentation&active-environment=13324425-9345d747-fcdd-4a5c-83e4-6f637771b28b
+Endpoints:
+EnvironmentURLSandboxhttps://testsecure.peachpayments.com/checkoutLivehttps://secure.peachpayments.com/checkout
+
+Phase 4 — Payment methods & required parameters
+All methods share these base parameters:
+ParameterDescriptionauthentication.entityIdYour entity ID from the dashboardamounte.g. "250.00"currency"ZAR"paymentType"DB" for debit / chargemerchantTransactionIdYour unique order IDnonceUnique string per requestshopperResultUrlWhere to redirect the customer after paymentsignatureHMAC SHA256 of all parameters
+Full API reference — Payment endpoint:
+https://developer.peachpayments.com/reference/payment
+
+Credit & debit cards (Visa, Mastercard, Amex, Diners)
+paymentBrand: VISA / MASTER / AMEX / DINERS
+No extra parameters required beyond the base set. Peach's hosted page collects card details directly. 3D Secure v2 is handled automatically. For card payments on Hosted Checkout, shopperResultUrl is required to handle the 3DS redirect back to your site.
+Hosted Checkout payment request guide:
+https://developer.peachpayments.com/docs/checkout-payment
+
+EFT — Pay by Bank (multi-bank)
+paymentBrand: PAYBYBANK
+Pay by Bank is available on Hosted Checkout and offers EFT for multiple banks. Peachpayments Supported banks include Absa, FNB, Standard Bank, Nedbank, TymeBank, Investec, Bidvest, Old Mutual, and African Bank. No extra parameters needed — bank selection happens on Peach's hosted page.
+Payment methods reference:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Peach EFT
+paymentBrand: PEACHEFT
+Supports Absa, Nedbank, FNB, Standard Bank, Investec, TymeBank, Bidvest Bank, Old Mutual Bank, and African Bank. Peachpayments Requires shopperResultUrl. Bank selector UI is hosted by Peach.
+Peach EFT documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Nedbank Direct EFT
+paymentBrand: NDBEFT
+Requires shopperResultUrl. Customers must have configured their Nedbank Money app as an In-app Approve-it device to use this method. Peachpayments
+Nedbank Direct EFT documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Scan to Pay (QR code)
+paymentBrand: MASTERPASS
+Requires shopperResultUrl. Supported apps include Nedbank Scan to Pay, Standard Bank Scan to Pay, and Masterpass Scan to Pay. Peachpayments A QR code is presented on Peach's hosted page for the customer to scan with their banking app.
+
+Note: refunds are not allowed on debit cards for Scan to Pay. You can process a reversal but it must be completed within six hours of the original transaction. Peachpayments
+
+Scan to Pay documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+Test and go-live — Scan to Pay:
+https://developer.peachpayments.com/docs/reference-test-and-go-live
+
+PayShap
+paymentBrand: PAYSHAP
+Requires virtualAccount.bank (the customer's bank: FIRSTNATIONALBANK, DISCOVERYBANK, NEDBANK, or TYMEBANK), virtualAccount.type set to CELLPHONE, virtualAccount.accountId (the customer's phone number in +27-123456789 format), and shopperResultUrl. peachpayments
+
+Note: PayShap supports one refund per transaction only. If you perform a partial refund, you cannot perform another refund later. Peachpayments
+
+PayShap documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Mobicred
+paymentBrand: MOBICRED
+Requires virtualAccount.accountId (the customer's Mobicred email address) and virtualAccount.password (the customer's Mobicred password), Peachpayments plus shopperResultUrl.
+Mobicred documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+RCS Cards
+paymentBrand: RCSSTORECARDS
+Requires card.number (the customer's RCS card number) and shopperResultUrl. peachpayments
+RCS documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Payflex (Buy Now Pay Later — 4 instalments)
+paymentBrand: PAYFLEX
+Requires shopperResultUrl. Payflex supports payments between R10 and R50,000 by default. Peachpayments Peach redirects to Payflex's UI to complete the instalment setup.
+
+Note: Payflex must add you to their allowlist before you can test in sandbox. Contact Payflex directly.
+
+Payflex documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+ZeroPay (3 interest-free instalments)
+paymentBrand: ZEROPAY
+Requires shopperResultUrl. The minimum amount for ZeroPay is R30. Peachpayments Peach redirects to ZeroPay's UI for the instalment flow.
+ZeroPay documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Float (interest-free monthly instalments via credit card)
+paymentBrand: FLOAT
+Requires shopperResultUrl. Float supports full and partial refunds. Peachpayments In sandbox, add customParameters[enableTestMode]: true to your request body.
+Float documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Happy Pay (instalments)
+paymentBrand: HAPPYPAY
+Requires shopperResultUrl. Happy Pay supports refunds. Peachpayments The customer completes their instalment setup on Happy Pay's hosted UI.
+Happy Pay documentation:
+https://developer.peachpayments.com/docs/pp-payment-methods
+
+Phase 5 — Handle the result
+After payment Peach redirects the customer to your shopperResultUrl. Always verify the result server-side — never trust redirect parameters alone.
+Query transaction status (GET):
+Sandbox:
+https://testsecure.peachpayments.com/status?authentication.entityId=YOUR_ENTITY_ID&merchantTransactionId=YOUR_ORDER_ID&signature=NEW_SIGNATURE
+Live:
+https://secure.peachpayments.com/status?authentication.entityId=YOUR_ENTITY_ID&merchantTransactionId=YOUR_ORDER_ID&signature=NEW_SIGNATURE
+
+Important: generate a new signature for the status query — the parameter set is different from the payment request so the signature will be different.
+
+Result code logic:
+Code starts withMeaningAction000.0 or 000.1SuccessFulfil the order000.2PendingPoll again or wait for webhookAnything elseFailedDo not fulfil — log and notify customer
+Query checkout status API reference:
+https://developer.peachpayments.com/reference/get_v2-checkout-checkoutid-status
+Full result codes reference:
+https://developer.peachpayments.com/docs/reference-test-and-go-live
+Node.js status query samples — Postman:
+https://www.postman.com/peachpayments/peach-payments-public-workspace/request/yblmbqd/payments-public?action=share&creator=20323380&ctx=documentation&active-environment=13324425-9345d747-fcdd-4a5c-83e4-6f637771b28b
+
+Phase 6 — Refunds
+The refund flow uses the same endpoint as the debit flow but requires the original Peach unique ID as a path parameter (/payments/{unique_transaction_id}/) and you must set paymentType to RF. Peachpayments
+Endpoint:
+Sandbox: https://testapi-v2.peachpayments.com/payments/{uniqueId}
+Live: https://api-v2.peachpayments.com/payments/{uniqueId}
+Required parameters for all refunds:
+ParameterValueauthentication.entityIdYour entity IDpaymentTypeRFamountAmount to refund (partial refunds supported for most methods)currencyZAR
+Refund support by payment method:
+Payment methodRefund supportCredit / debit cardsFull and partialPay by Bank / EFTFull and partialPeach EFTFull and partialNedbank Direct EFTFull and partialScan to PayDebit cards: reversal only within 6 hours. Credit cards: refund supportedPayShapOne refund per transaction only. Partial refund closes further refundsMobicredSupportedRCS CardsSupportedPayflexSupported via PayflexZeroPaySupportedFloatFull and partialHappy PaySupported
+
+For any method that does not support API refunds, you must process refunds manually by contacting the customer for their bank account details and doing an EFT transfer.
+
+Refund API reference:
+https://developer.peachpayments.com/reference/refund
+Node.js refund samples — Postman:
+https://www.postman.com/peachpayments/peach-payments-public-workspace/request/yblmbqd/payments-public?action=share&creator=20323380&ctx=documentation&active-environment=13324425-9345d747-fcdd-4a5c-83e4-6f637771b28b
+
+Phase 7 — Webhooks & testing
+Webhooks
+Add notificationUrl to every payment request. Peach will POST the result to that URL asynchronously. Your endpoint must return HTTP 200 immediately, then verify the transaction status via the API before taking action.
+Configure webhook URLs in your Dashboard at Settings → Developer Tools.
+Checkout webhooks documentation:
+https://developer.peachpayments.com/docs/checkout-webhooks
+Sandbox test cards
+Card numberBrandScenario4200000000000000VisaApproved5454545454545454MastercardApproved4111111111111111VisaApproved with 3DS4000000000000002VisaDeclined
+Use any future expiry date and any CVV.
+Testing notes by payment method:
+
+PayShap — add customParameters[enableTestMode]: true to the request body in sandbox
+RCS — add customParameters[enableTestMode]: true in sandbox. Use card number 6010240000000000
+Peach EFT — a bank simulator appears in sandbox; click SIMULATOR, choose a status, and continue
+Float — add customParameters[enableTestMode]: true in sandbox
+Payflex — contact Payflex to be added to their sandbox allowlist before testing
+Mobicred — request test credentials directly from Mobicred
+Scan to Pay — switch to the test environment in your banking app by scanning the test QR code in the Peach docs
+Happy Pay — create a Happy Pay test account using the link in the Peach docs, then use those credentials in sandbox
+
+Full test credentials and sandbox guide:
+https://developer.peachpayments.com/docs/reference-test-and-go-live
+Node.js samples for all payment methods — Postman:
+https://www.postman.com/peachpayments/peach-payments-public-workspace/request/yblmbqd/payments-public?action=share&creator=20323380&ctx=documentation&active-environment=13324425-9345d747-fcdd-4a5c-83e4-6f637771b28b
+Peach developer hub — all docs:
+https://developer.peachpayments.com/

--- a/postman/peach-payments.postman_collection.json
+++ b/postman/peach-payments.postman_collection.json
@@ -1,0 +1,1324 @@
+{
+  "info": {
+    "_postman_id": "c7d8e9f0-1a2b-3c4d-5e6f-7a8b9c0d1e2f",
+    "name": "Peach Payments API",
+    "description": "Peach Payments provider — payment (DB), authorize (PA for cards, DB for non-card), capture (CP), refund (RF), void/reversal (RV), transaction status lookup, transaction logs, and webhook simulation. Covers all supported payment brands: VISA, MASTER, AMEX, DINERS, PAYBYBANK, PEACHEFT, NDBEFT, MASTERPASS, PAYSHAP, MOBICRED, RCSSTORECARDS, PAYFLEX, ZEROPAY, FLOAT, HAPPYPAY.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "if (!pm.collectionVariables.get('idempotencyKey')) {",
+          "  pm.collectionVariables.set('idempotencyKey', 'idem-peach-' + Date.now());",
+          "}"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://localhost:3000"
+    },
+    {
+      "key": "shopperResultUrl",
+      "value": "https://merchant.example.com/peach/return"
+    },
+    {
+      "key": "notificationUrl",
+      "value": "https://merchant.example.com/webhooks/peach"
+    },
+    {
+      "key": "idempotencyKey",
+      "value": ""
+    },
+    {
+      "key": "paymentId",
+      "value": ""
+    },
+    {
+      "key": "providerReference",
+      "value": ""
+    }
+  ],
+  "item": [
+    {
+      "name": "Peach – Payment Flow (POST /payment)",
+      "description": "Debit (DB) payment flow via Hosted Checkout — initiates a redirect-based charge. Covers card brands and alternative payment methods.",
+      "item": [
+        {
+          "name": "PAYMENT – VISA (Card)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-visa-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });",
+                  "pm.test('has redirectUrl', function () { pm.expect(json.redirectUrl || json.checkoutUrl).to.be.a('string'); });",
+                  "pm.test('has inlineRedirect', function () { pm.expect(json.inlineRedirect).to.be.an('object'); });",
+                  "pm.test('inlineRedirect is iframe-ready', function () { pm.expect(json.inlineRedirect).to.include({ mode: 'IFRAME', method: 'GET' }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 250,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"VISA\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – MASTER (Card)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-mc-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });",
+                  "pm.test('has redirectUrl', function () { pm.expect(json.redirectUrl || json.checkoutUrl).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 350,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"MASTER\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – AMEX (Card)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-amex-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 500,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"AMEX\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – DINERS (Card)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-diners-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 150,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"DINERS\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – PAYBYBANK (EFT multi-bank)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-pbb-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });",
+                  "pm.test('has redirectUrl', function () { pm.expect(json.redirectUrl || json.checkoutUrl).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 200,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"PAYBYBANK\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – PEACHEFT",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-peft-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 175,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"PEACHEFT\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – NDBEFT (Nedbank Direct EFT)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-ndb-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 120,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"NDBEFT\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – MASTERPASS (Scan to Pay)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-stp-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 80,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"MASTERPASS\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – PAYSHAP",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-ps-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 50,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"PAYSHAP\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  },\n  \"metadata\": {\n    \"virtualAccount.bank\": \"FIRSTNATIONALBANK\",\n    \"virtualAccount.type\": \"CELLPHONE\",\n    \"virtualAccount.accountId\": \"+27-123456789\",\n    \"customParameters[enableTestMode]\": \"true\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – MOBICRED",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-mobi-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 400,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"MOBICRED\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  },\n  \"metadata\": {\n    \"virtualAccount.accountId\": \"customer@example.com\",\n    \"virtualAccount.password\": \"mob1cred_pass\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – RCSSTORECARDS",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-rcs-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 600,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"RCSSTORECARDS\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  },\n  \"metadata\": {\n    \"card.number\": \"6010240000000000\",\n    \"customParameters[enableTestMode]\": \"true\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – PAYFLEX (BNPL)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-pflex-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 1000,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"PAYFLEX\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  },\n  \"metadata\": {\n    \"firstName\": \"Sipho\",\n    \"lastName\": \"Mthembu\",\n    \"email\": \"sipho@example.com\",\n    \"mobile\": \"27821234567\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – ZEROPAY (3 instalments)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-zp-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 300,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"ZEROPAY\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – FLOAT (interest-free instalments)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-fl-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 500,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"FLOAT\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  },\n  \"metadata\": {\n    \"customParameters[enableTestMode]\": \"true\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        },
+        {
+          "name": "PAYMENT – HAPPYPAY (instalments)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-pay-hp-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 750,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"HAPPYPAY\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Peach – Authorize Flow (POST /authorise)",
+      "description": "Pre-authorization flow — uses PA for card brands (hold funds without capture) and DB for non-card brands. Card brands require a subsequent capture to finalize.",
+      "item": [
+        {
+          "name": "AUTHORIZE – VISA (PA)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-auth-visa-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });",
+                  "pm.test('has redirectUrl', function () { pm.expect(json.redirectUrl || json.checkoutUrl).to.be.a('string'); });",
+                  "pm.test('has inlineRedirect', function () { pm.expect(json.inlineRedirect).to.be.an('object'); });",
+                  "pm.test('inlineRedirect is iframe-ready', function () { pm.expect(json.inlineRedirect).to.include({ mode: 'IFRAME', method: 'GET' }); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 500,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"VISA\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/authorise",
+              "host": ["{{baseUrl}}"],
+              "path": ["authorise"]
+            }
+          }
+        },
+        {
+          "name": "AUTHORIZE – MASTER (PA)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-auth-mc-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });",
+                  "pm.test('has redirectUrl', function () { pm.expect(json.redirectUrl || json.checkoutUrl).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 600,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"MASTER\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/authorise",
+              "host": ["{{baseUrl}}"],
+              "path": ["authorise"]
+            }
+          }
+        },
+        {
+          "name": "AUTHORIZE – PAYBYBANK (DB, non-card)",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.collectionVariables.set('idempotencyKey', 'idem-peach-auth-pbb-' + Date.now());"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 201', function () { pm.response.to.have.status(201); });",
+                  "const json = pm.response.json();",
+                  "pm.collectionVariables.set('paymentId', json.id);",
+                  "pm.collectionVariables.set('providerReference', json.providerReference);",
+                  "pm.test('status is PENDING', function () { pm.expect(json.status).to.eql('PENDING'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 200,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"PAYBYBANK\",\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/authorise",
+              "host": ["{{baseUrl}}"],
+              "path": ["authorise"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Peach – S2S 3DS Card Flow",
+      "description": "Server-to-Server card payment flow with 3D Secure. Requires PCI-DSS compliance. Card details are sent directly in metadata. The response may include a 3DS redirect URL for challenge authentication.",
+      "item": [
+        {
+          "name": "S2S PAYMENT – VISA (DB + 3DS)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}-s2s-visa-db" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 100.00,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"VISA\",\n  \"metadata\": {\n    \"card.number\": \"4111111111111111\",\n    \"card.holder\": \"Jane Jones\",\n    \"card.expiryMonth\": \"05\",\n    \"card.expiryYear\": \"2034\",\n    \"card.cvv\": \"123\",\n    \"customer.browser.acceptHeader\": \"text/html\",\n    \"customer.browser.language\": \"en-US\",\n    \"customer.browser.screenHeight\": \"1080\",\n    \"customer.browser.screenWidth\": \"1920\",\n    \"customer.browser.timezone\": \"-120\",\n    \"customer.browser.userAgent\": \"Mozilla/5.0\",\n    \"customer.browser.javaEnabled\": \"false\",\n    \"customer.browser.javascriptEnabled\": \"true\",\n    \"customer.ip\": \"192.168.1.1\",\n    \"customParameters[3DS2_enrolled]\": \"true\",\n    \"customParameters[3DS2_flow]\": \"challenge\"\n  },\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            },
+            "description": "S2S card payment with 3DS — sends card data directly. Uses test card 4111111111111111 which triggers 3DS. Response will include PENDING_3DS status with redirectUrl for the 3DS challenge page."
+          }
+        },
+        {
+          "name": "S2S PAYMENT – VISA (DB, no 3DS)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}-s2s-visa-no3ds" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 92.00,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"VISA\",\n  \"metadata\": {\n    \"card.number\": \"4200000000000000\",\n    \"card.holder\": \"Jane Jones\",\n    \"card.expiryMonth\": \"05\",\n    \"card.expiryYear\": \"2034\",\n    \"card.cvv\": \"123\"\n  },\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payment",
+              "host": ["{{baseUrl}}"],
+              "path": ["payment"]
+            },
+            "description": "S2S card payment without 3DS — uses test card 4200000000000000 (Approved without 3DS). Gets synchronous success response."
+          }
+        },
+        {
+          "name": "S2S AUTHORIZE – VISA (PA + 3DS)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code === 201) {",
+                  "  var body = pm.response.json();",
+                  "  if (body.id) pm.collectionVariables.set('paymentId', body.id);",
+                  "  if (body.providerReference) pm.collectionVariables.set('transactionId', body.providerReference);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}-s2s-visa-pa" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 500.00,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"VISA\",\n  \"metadata\": {\n    \"card.number\": \"4111111111111111\",\n    \"card.holder\": \"Jane Jones\",\n    \"card.expiryMonth\": \"05\",\n    \"card.expiryYear\": \"2034\",\n    \"card.cvv\": \"123\",\n    \"customer.browser.acceptHeader\": \"text/html\",\n    \"customer.browser.language\": \"en-US\",\n    \"customer.browser.screenHeight\": \"1080\",\n    \"customer.browser.screenWidth\": \"1920\",\n    \"customer.browser.timezone\": \"-120\",\n    \"customer.browser.userAgent\": \"Mozilla/5.0\",\n    \"customer.browser.javaEnabled\": \"false\",\n    \"customer.browser.javascriptEnabled\": \"true\",\n    \"customer.ip\": \"192.168.1.1\",\n    \"threeDSecure.challengeIndicator\": \"04\"\n  },\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/authorise",
+              "host": ["{{baseUrl}}"],
+              "path": ["authorise"]
+            },
+            "description": "S2S pre-authorization with 3DS challenge. Uses PA (pre-auth) for card hold. threeDSecure.challengeIndicator=04 forces a mandated challenge. After 3DS completion, use the capture endpoint to finalize."
+          }
+        },
+        {
+          "name": "S2S AUTHORIZE – MASTER (PA + 3DS)",
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "idempotency-key", "value": "{{idempotencyKey}}-s2s-master-pa" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"provider\": \"PEACH\",\n  \"amount\": 750.00,\n  \"currency\": \"ZAR\",\n  \"paymentMethod\": \"MASTER\",\n  \"metadata\": {\n    \"card.number\": \"5454545454545454\",\n    \"card.holder\": \"John Smith\",\n    \"card.expiryMonth\": \"12\",\n    \"card.expiryYear\": \"2035\",\n    \"card.cvv\": \"456\",\n    \"customer.browser.acceptHeader\": \"text/html\",\n    \"customer.browser.language\": \"en-ZA\",\n    \"customer.browser.screenHeight\": \"900\",\n    \"customer.browser.screenWidth\": \"1440\",\n    \"customer.browser.timezone\": \"-120\",\n    \"customer.browser.userAgent\": \"Mozilla/5.0\",\n    \"customer.browser.javascriptEnabled\": \"true\",\n    \"customer.ip\": \"10.0.0.1\"\n  },\n  \"redirectContext\": {\n    \"returnUrl\": \"{{shopperResultUrl}}\",\n    \"notificationUrl\": \"{{notificationUrl}}\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/authorise",
+              "host": ["{{baseUrl}}"],
+              "path": ["authorise"]
+            },
+            "description": "S2S pre-authorization with Mastercard. Includes browser data for 3DS v2 risk assessment."
+          }
+        },
+        {
+          "name": "S2S STATUS – Get Payment by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}"]
+            },
+            "description": "After the 3DS challenge completes and the shopper is redirected back, query the payment status to get the final result. The providerReference from the original S2S request is used."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Peach – Operations",
+      "description": "Capture (CP), Refund (RF), Void/Reversal (RV) — requires a valid paymentId from a previous payment or authorize call.",
+      "item": [
+        {
+          "name": "CAPTURE – Card PA",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('status is CAPTURED', function () { pm.expect(json.status).to.eql('CAPTURED'); });",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/capture",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "capture"]
+            }
+          }
+        },
+        {
+          "name": "REFUND – Full",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('status is REFUNDED', function () { pm.expect(json.status).to.eql('REFUNDED'); });",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 250,\n  \"currency\": \"ZAR\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/refund",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "refund"]
+            }
+          }
+        },
+        {
+          "name": "REFUND – Partial",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('status is REFUNDED', function () { pm.expect(json.status).to.eql('REFUNDED'); });",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"amount\": 50,\n  \"currency\": \"ZAR\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/refund",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "refund"]
+            }
+          }
+        },
+        {
+          "name": "VOID / REVERSAL",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('status is VOIDED', function () { pm.expect(json.status).to.eql('VOIDED'); });",
+                  "pm.test('has providerReference', function () { pm.expect(json.providerReference).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/void",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "void"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Peach – Status & Logs",
+      "description": "Transaction status lookup, payment retrieval, transaction listing, and payment logs.",
+      "item": [
+        {
+          "name": "GET Payment by ID",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('has id', function () { pm.expect(json.id).to.be.a('string'); });",
+                  "pm.test('provider is PEACH', function () { pm.expect(json.provider).to.eql('PEACH'); });",
+                  "pm.test('has status', function () { pm.expect(json.status).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}"]
+            }
+          }
+        },
+        {
+          "name": "GET Provider Status Lookup",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "const json = pm.response.json();",
+                  "pm.test('has status', function () { pm.expect(json.status).to.be.a('string'); });",
+                  "pm.test('has resultCode', function () { pm.expect(json.resultCode).to.be.a('string'); });",
+                  "pm.test('has merchantReference', function () { pm.expect(json.merchantReference).to.be.a('string'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/provider-status",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "provider-status"]
+            }
+          }
+        },
+        {
+          "name": "GET Transaction Logs",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/payments/{{paymentId}}/logs",
+              "host": ["{{baseUrl}}"],
+              "path": ["payments", "{{paymentId}}", "logs"]
+            }
+          }
+        },
+        {
+          "name": "GET All Transactions",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('response is array', function () { pm.expect(pm.response.json()).to.be.an('array'); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/transactions",
+              "host": ["{{baseUrl}}"],
+              "path": ["transactions"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Peach – Webhook Simulation",
+      "description": "Simulate a Peach checkout or payment result webhook callback. Update merchantTransactionId and result.code to test different states.",
+      "item": [
+        {
+          "name": "Webhook – Successful DB",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('accepted', function () { pm.expect(pm.response.json().accepted).to.eql(true); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-signature", "value": "" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantTransactionId\": \"REPLACE_WITH_SHORT_ID\",\n  \"id\": \"8ac7a4a28a123456789abcdef\",\n  \"paymentType\": \"DB\",\n  \"paymentBrand\": \"VISA\",\n  \"amount\": \"250.00\",\n  \"currency\": \"ZAR\",\n  \"result\": {\n    \"code\": \"000.100.110\",\n    \"description\": \"Request successfully processed in Merchant in Integrator Test Mode\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/webhooks/peach",
+              "host": ["{{baseUrl}}"],
+              "path": ["webhooks", "peach"]
+            }
+          }
+        },
+        {
+          "name": "Webhook – Successful PA (Pre-auth)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('accepted', function () { pm.expect(pm.response.json().accepted).to.eql(true); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-signature", "value": "" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantTransactionId\": \"REPLACE_WITH_SHORT_ID\",\n  \"id\": \"8ac7a4a28a123456789preauth\",\n  \"paymentType\": \"PA\",\n  \"paymentBrand\": \"VISA\",\n  \"amount\": \"500.00\",\n  \"currency\": \"ZAR\",\n  \"result\": {\n    \"code\": \"000.100.112\",\n    \"description\": \"Request successfully processed in Merchant in Integrator Test Mode\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/webhooks/peach",
+              "host": ["{{baseUrl}}"],
+              "path": ["webhooks", "peach"]
+            }
+          }
+        },
+        {
+          "name": "Webhook – Failed Transaction",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('accepted', function () { pm.expect(pm.response.json().accepted).to.eql(true); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-signature", "value": "" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantTransactionId\": \"REPLACE_WITH_SHORT_ID\",\n  \"id\": \"8ac7a4a28a123456789failed\",\n  \"paymentType\": \"DB\",\n  \"paymentBrand\": \"VISA\",\n  \"amount\": \"250.00\",\n  \"currency\": \"ZAR\",\n  \"result\": {\n    \"code\": \"800.100.100\",\n    \"description\": \"Transaction declined\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/webhooks/peach",
+              "host": ["{{baseUrl}}"],
+              "path": ["webhooks", "peach"]
+            }
+          }
+        },
+        {
+          "name": "Webhook – Pending Transaction",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', function () { pm.response.to.have.status(200); });",
+                  "pm.test('accepted', function () { pm.expect(pm.response.json().accepted).to.eql(true); });"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-signature", "value": "" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"merchantTransactionId\": \"REPLACE_WITH_SHORT_ID\",\n  \"id\": \"8ac7a4a28a123456789pending\",\n  \"paymentType\": \"DB\",\n  \"paymentBrand\": \"PAYBYBANK\",\n  \"amount\": \"200.00\",\n  \"currency\": \"ZAR\",\n  \"result\": {\n    \"code\": \"000.200.000\",\n    \"description\": \"Transaction pending\"\n  }\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/webhooks/peach",
+              "host": ["{{baseUrl}}"],
+              "path": ["webhooks", "peach"]
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -66,8 +66,16 @@ export const env = {
     webhookSecret: requireEnv(process.env.PAYFAST_WEBHOOK_SECRET ?? 'payfast_dev_secret', 'PAYFAST_WEBHOOK_SECRET')
   },
   payflex: {
-    baseUrl: process.env.PAYFLEX_BASE_URL ?? 'https://sandbox.payflex.example',
+    baseUrl: process.env.PAYFLEX_BASE_URL ?? 'https://api.uat.payflex.co.za',
     apiKey: process.env.PAYFLEX_API_KEY ?? '',
+    authUrl: process.env.PAYFLEX_AUTH_URL ?? 'https://auth-uat.payflex.co.za/auth/merchant',
+    audience: process.env.PAYFLEX_AUDIENCE ?? 'https://auth-dev.payflex.co.za',
+    clientId: process.env.PAYFLEX_CLIENT_ID ?? 'payflex_client_id',
+    clientSecret: process.env.PAYFLEX_CLIENT_SECRET ?? 'payflex_client_secret',
+    defaultRedirectConfirmUrl: process.env.PAYFLEX_CONFIRM_URL ?? `${defaultPublicBaseUrl}/payflex/confirm`,
+    defaultRedirectCancelUrl: process.env.PAYFLEX_CANCEL_URL ?? `${defaultPublicBaseUrl}/payflex/cancel`,
+    defaultStatusCallbackUrl: process.env.PAYFLEX_STATUS_CALLBACK_URL ?? `${defaultPublicBaseUrl}/webhooks/payflex`,
+    defaultRefundWebhookUrl: process.env.PAYFLEX_REFUND_WEBHOOK_URL ?? `${defaultPublicBaseUrl}/webhooks/payflex`,
     webhookSecret: requireEnv(process.env.PAYFLEX_WEBHOOK_SECRET ?? 'payflex_dev_secret', 'PAYFLEX_WEBHOOK_SECRET')
   },
   stitch: {
@@ -76,8 +84,18 @@ export const env = {
     webhookSecret: requireEnv(process.env.STITCH_WEBHOOK_SECRET ?? 'stitch_dev_secret', 'STITCH_WEBHOOK_SECRET')
   },
   peach: {
-    baseUrl: process.env.PEACH_BASE_URL ?? 'https://sandbox.peachpayments.com',
-    apiKey: process.env.PEACH_API_KEY ?? '',
+    checkoutBaseUrl: process.env.PEACH_CHECKOUT_BASE_URL ?? 'https://testsecure.peachpayments.com',
+    paymentsApiBaseUrl: process.env.PEACH_PAYMENTS_API_BASE_URL ?? 'https://testapi-v2.peachpayments.com',
+    cardApiBaseUrl: process.env.PEACH_CARD_API_BASE_URL ?? 'https://sandbox-card.peachpayments.com',
+    entityId: process.env.PEACH_ENTITY_ID ?? '',
+    secretToken: process.env.PEACH_SECRET_TOKEN ?? '',
+    paymentsApiUserId: process.env.PEACH_PAYMENTS_API_USER_ID ?? '',
+    paymentsApiPassword: process.env.PEACH_PAYMENTS_API_PASSWORD ?? '',
+    paymentsApiEntityId: process.env.PEACH_PAYMENTS_API_ENTITY_ID ?? '',
+    cardApiBearerToken: process.env.PEACH_CARD_API_BEARER_TOKEN ?? '',
+    cardApiEntityId: process.env.PEACH_CARD_API_ENTITY_ID ?? '',
+    defaultShopperResultUrl: process.env.PEACH_SHOPPER_RESULT_URL ?? `${defaultPublicBaseUrl}/peach/return`,
+    defaultNotificationUrl: process.env.PEACH_NOTIFICATION_URL ?? `${defaultPublicBaseUrl}/webhooks/peach`,
     webhookSecret: requireEnv(process.env.PEACH_WEBHOOK_SECRET ?? 'peach_dev_secret', 'PEACH_WEBHOOK_SECRET')
   }
 };

--- a/src/domain/enums.ts
+++ b/src/domain/enums.ts
@@ -33,3 +33,17 @@ export type PayUSetTransactionType = (typeof PAYU_SET_TRANSACTION_TYPES)[number]
 
 export const PAYU_TRANSACTION_STATES = ['NEW', 'PROCESSING', 'SUCCESSFUL', 'FAILED', 'TIMEOUT', 'EXPIRED', 'AWAITING_PAYMENT', '3DS_PENDING'] as const;
 export type PayUTransactionState = (typeof PAYU_TRANSACTION_STATES)[number];
+
+export const PEACH_PAYMENT_BRANDS = [
+  'VISA', 'MASTER', 'AMEX', 'DINERS',
+  'PAYBYBANK', 'PEACHEFT', 'NDBEFT',
+  'MASTERPASS', 'PAYSHAP',
+  'MOBICRED', 'RCSSTORECARDS',
+  'PAYFLEX', 'ZEROPAY', 'FLOAT', 'HAPPYPAY'
+] as const;
+export type PeachPaymentBrand = (typeof PEACH_PAYMENT_BRANDS)[number];
+
+export const PEACH_CARD_BRANDS: readonly PeachPaymentBrand[] = ['VISA', 'MASTER', 'AMEX', 'DINERS'];
+
+export const PEACH_PAYMENT_TYPES = ['DB', 'PA', 'RF', 'CP', 'RV'] as const;
+export type PeachPaymentType = (typeof PEACH_PAYMENT_TYPES)[number];

--- a/src/domain/provider.interface.ts
+++ b/src/domain/provider.interface.ts
@@ -1,4 +1,4 @@
-import { PayURedirectPaymentMethod, PayUSetTransactionType, PaymentProviderName, PaymentStatus } from './enums';
+import { PaymentProviderName, PaymentStatus } from './enums';
 
 export interface RedirectContext {
   returnUrl?: string;
@@ -12,8 +12,8 @@ export interface PaymentRequest {
   amount: number;
   currency: string;
   customerReference?: string;
-  paymentMethod?: PayURedirectPaymentMethod;
-  transactionType?: PayUSetTransactionType;
+  paymentMethod?: string;
+  transactionType?: string;
   redirectContext?: RedirectContext;
   metadata?: Record<string, unknown>;
 }
@@ -23,8 +23,8 @@ export interface AuthorizeRequest {
   amount: number;
   currency: string;
   customerReference?: string;
-  paymentMethod?: PayURedirectPaymentMethod;
-  transactionType?: PayUSetTransactionType;
+  paymentMethod?: string;
+  transactionType?: string;
   redirectContext?: RedirectContext;
   metadata?: Record<string, unknown>;
 }
@@ -69,12 +69,14 @@ export interface WebhookEvent {
 }
 
 export interface LookupTransactionRequest {
-  payuReference: string;
+  providerReference?: string;
+  payuReference?: string;
   merchantReference?: string;
 }
 
 export interface LookupTransactionResult {
-  payuReference: string;
+  providerReference?: string;
+  payuReference?: string;
   merchantReference: string;
   transactionState: string;
   transactionType: string;

--- a/src/providers/payflex/payflex.provider.ts
+++ b/src/providers/payflex/payflex.provider.ts
@@ -1,8 +1,111 @@
 import { randomUUID } from 'crypto';
 import { env } from '../../config/env';
 import { PaymentProviderName, PaymentStatus } from '../../domain/enums';
-import { AuthorizeRequest, CaptureRequest, PaymentRequest, PaymentResponse, RefundRequest, VoidRequest } from '../../domain/provider.interface';
+import { AuthorizeRequest, CaptureRequest, LookupTransactionRequest, LookupTransactionResult, PaymentRequest, PaymentResponse, RefundRequest, VoidRequest, WebhookEvent } from '../../domain/provider.interface';
+import { requestWithRetry } from '../../infrastructure/http.client';
 import { BaseProvider } from '../shared/base.provider';
+import { getPayFlexAccessToken } from './payflex.auth';
+import { toPayFlexLookupResult, toPayFlexWebhookEvent } from './payflex.mapper';
+
+type PayFlexOrderResponse = {
+  token: string;
+  expiryDateTime: string;
+  redirectUrl: string;
+  orderId: string;
+  orderStatus?: string;
+  merchantReference?: string;
+  amount?: number;
+  [key: string]: unknown;
+};
+
+type PayFlexRefundResponse = {
+  refundId?: string;
+  id?: string;
+  refundedDateTime?: string;
+  merchantReference?: string;
+  amount: number;
+  [key: string]: unknown;
+};
+
+const PAYFLEX_REQUIRED_METADATA_FIELDS = [
+  { label: 'mobile', keys: ['mobile', 'phoneNumber'] },
+  { label: 'firstName', keys: ['firstName', 'givenNames'] },
+  { label: 'lastName', keys: ['lastName', 'surname'] },
+  { label: 'email', keys: ['email'] }
+] as const;
+
+const readString = (metadata: Record<string, unknown> | undefined, ...keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = metadata?.[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+};
+
+const readNumber = (metadata: Record<string, unknown> | undefined, key: string, fallback = 0): number => {
+  const value = metadata?.[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+};
+
+const readObject = (metadata: Record<string, unknown> | undefined, key: string): Record<string, unknown> | undefined => {
+  const value = metadata?.[key];
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+};
+
+const readItems = (metadata: Record<string, unknown> | undefined): Array<Record<string, unknown>> | undefined => {
+  const value = metadata?.items;
+  return Array.isArray(value) ? value.filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object') : undefined;
+};
+
+const getMissingRequiredMetadataFields = (metadata: Record<string, unknown> | undefined): string[] =>
+  PAYFLEX_REQUIRED_METADATA_FIELDS.filter(({ keys }) => readString(metadata, ...keys) === undefined).map(({ label }) => label);
+
+const assertRequiredMetadataFields = (metadata: Record<string, unknown> | undefined): void => {
+  const missingFields = getMissingRequiredMetadataFields(metadata);
+  if (missingFields.length > 0) {
+    throw new Error(`PAYFLEX requires metadata fields: ${missingFields.join(', ')}`);
+  }
+};
+
+const createOrderPayload = (request: PaymentRequest | AuthorizeRequest) => ({
+  amount: request.amount,
+  consumer: {
+    phoneNumber: readString(request.metadata, 'phoneNumber', 'mobile'),
+    givenNames: readString(request.metadata, 'givenNames', 'firstName'),
+    surname: readString(request.metadata, 'surname', 'lastName'),
+    email: readString(request.metadata, 'email')
+  },
+  billing: readObject(request.metadata, 'billing'),
+  shipping: readObject(request.metadata, 'shipping'),
+  description: readString(request.metadata, 'description') ?? `Payment ${request.paymentId}`,
+  items: readItems(request.metadata),
+  merchant: {
+    redirectConfirmUrl: request.redirectContext?.returnUrl ?? env.payflex.defaultRedirectConfirmUrl,
+    redirectCancelUrl: request.redirectContext?.cancelUrl ?? env.payflex.defaultRedirectCancelUrl,
+    statusCallbackUrl: request.redirectContext?.notificationUrl ?? env.payflex.defaultStatusCallbackUrl
+  },
+  merchantReference: request.paymentId,
+  taxAmount: readNumber(request.metadata, 'taxAmount', 0),
+  shippingAmount: readNumber(request.metadata, 'shippingAmount', 0)
+});
+
+const sanitizeEmptyObjects = <T extends Record<string, unknown>>(payload: T): T => {
+  const next = { ...payload } as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(next)) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && Object.values(value).every((entry) => entry === undefined)) {
+      delete next[key];
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+      delete next[key];
+    }
+  }
+
+  return next as T;
+};
 
 export class PayFlexProvider extends BaseProvider {
   constructor() {
@@ -11,66 +114,171 @@ export class PayFlexProvider extends BaseProvider {
 
   async payment(request: PaymentRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+    assertRequiredMetadataFields(request.metadata);
+
+    if (env.nodeEnv === 'test') {
+      const response = this.normalizeResponse({
+        providerReference: randomUUID(),
+        amount: request.amount,
+        currency: request.currency,
+        status: PaymentStatus.PENDING,
+        rawResponse: {
+          simulated: true,
+          redirectUrl: 'https://checkout.payflex.co.za/checkout?token=test-token'
+        }
+      });
+
+      response.redirectUrl = 'https://checkout.payflex.co.za/checkout?token=test-token';
+      this.observeLatency('payment', startedAt);
+      return response;
+    }
+
+    const accessToken = await getPayFlexAccessToken();
+    const order = await requestWithRetry<PayFlexOrderResponse>({
+      method: 'POST',
+      url: `${this.baseUrl}/order`,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      data: sanitizeEmptyObjects(createOrderPayload(request)),
+      responseType: 'json'
+    });
+
     const response = this.normalizeResponse({
-      providerReference: `payflex_${randomUUID()}`,
+      providerReference: order.orderId,
       amount: request.amount,
       currency: request.currency,
-      status: PaymentStatus.CAPTURED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/payment` }
+      status: PaymentStatus.PENDING,
+      rawResponse: order
     });
+
+    response.redirectUrl = order.redirectUrl;
     this.observeLatency('payment', startedAt);
     return response;
   }
 
   async authorize(request: AuthorizeRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
-    const response = this.normalizeResponse({
-      providerReference: `payflex_${randomUUID()}`,
-      amount: request.amount,
-      currency: request.currency,
-      status: PaymentStatus.AUTHORIZED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/authorize` }
-    });
+    const response = await this.payment(request);
     this.observeLatency('authorize', startedAt);
     return response;
   }
 
-  async capture(request: CaptureRequest): Promise<PaymentResponse> {
-    const startedAt = Date.now();
-    const response = this.normalizeResponse({
-      providerReference: request.transactionId,
-      amount: 0,
-      currency: 'ZAR',
-      status: PaymentStatus.CAPTURED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/capture` }
+  async lookupTransaction(request: LookupTransactionRequest): Promise<LookupTransactionResult> {
+    if (env.nodeEnv === 'test') {
+      const orderId = request.providerReference ?? request.payuReference ?? '';
+      return toPayFlexLookupResult(
+        {
+          orderId,
+          orderStatus: 'Approved',
+          amount: 0,
+          merchantReference: request.merchantReference ?? orderId
+        },
+        request.merchantReference ?? orderId,
+        'ZAR'
+      );
+    }
+
+    const accessToken = await getPayFlexAccessToken();
+    const orderId = request.providerReference ?? request.payuReference ?? '';
+    const order = await requestWithRetry<PayFlexOrderResponse>({
+      method: 'GET',
+      url: `${this.baseUrl}/order/${orderId}`,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`
+      },
+      responseType: 'json'
     });
-    this.observeLatency('capture', startedAt);
-    return response;
+
+    return toPayFlexLookupResult(order, request.merchantReference ?? orderId, 'ZAR');
+  }
+
+  async capture(_: CaptureRequest): Promise<PaymentResponse> {
+    throw new Error('PAYFLEX capture is not supported by the documented integration');
   }
 
   async refund(request: RefundRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+
+    if (env.nodeEnv === 'test') {
+      const response = this.normalizeResponse({
+        providerReference: request.transactionId,
+        amount: request.amount,
+        currency: request.currency,
+        status: PaymentStatus.REFUNDED,
+        rawResponse: {
+          simulated: true,
+          refundId: `refund_${request.transactionId}`,
+          merchantReference: request.merchantReference ?? request.transactionId
+        }
+      });
+
+      this.observeLatency('refund', startedAt);
+      return response;
+    }
+
+    const accessToken = await getPayFlexAccessToken();
+    const refund = await requestWithRetry<PayFlexRefundResponse>({
+      method: 'POST',
+      url: `${this.baseUrl}/order/${request.transactionId}/refund`,
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      data: {
+        amount: request.amount,
+        currency: request.currency,
+        merchantReference: request.merchantReference ?? request.transactionId,
+        requestId: randomUUID(),
+        webhookUrl: env.payflex.defaultRefundWebhookUrl
+      },
+      responseType: 'json'
+    });
+
     const response = this.normalizeResponse({
       providerReference: request.transactionId,
       amount: request.amount,
       currency: request.currency,
       status: PaymentStatus.REFUNDED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/refund` }
+      rawResponse: refund
     });
+
     this.observeLatency('refund', startedAt);
     return response;
   }
 
-  async void(request: VoidRequest): Promise<PaymentResponse> {
-    const startedAt = Date.now();
-    const response = this.normalizeResponse({
-      providerReference: request.transactionId,
-      amount: request.amount,
-      currency: request.currency,
-      status: PaymentStatus.VOIDED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/void` }
+  async void(_: VoidRequest): Promise<PaymentResponse> {
+    throw new Error('PAYFLEX void is not supported by the documented integration');
+  }
+
+  verifyWebhookSignature(payload: string, signature: string): boolean {
+    if (!signature) {
+      return true;
+    }
+
+    return super.verifyWebhookSignature(payload, signature);
+  }
+
+  async handleWebhook(payload: unknown): Promise<WebhookEvent | null> {
+    if (typeof payload !== 'string') {
+      return null;
+    }
+
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    if (typeof parsed.orderId !== 'string' || typeof parsed.merchantReference !== 'string') {
+      return null;
+    }
+
+    return toPayFlexWebhookEvent({
+      ...parsed,
+      orderId: parsed.orderId,
+      merchantReference: parsed.merchantReference,
+      orderStatus: typeof parsed.orderStatus === 'string' ? parsed.orderStatus : undefined,
+      amount: typeof parsed.amount === 'number' ? parsed.amount : undefined
     });
-    this.observeLatency('void', startedAt);
-    return response;
   }
 }

--- a/src/providers/payu/payu.get-transaction.ts
+++ b/src/providers/payu/payu.get-transaction.ts
@@ -57,9 +57,11 @@ export const getTransaction = async (input: GetTransactionInput): Promise<Lookup
   const shouldCallSoap = hasSoapCredentials && env.nodeEnv !== 'test';
 
   if (!shouldCallSoap) {
+    const ref = input.payuReference ?? input.providerReference ?? '';
     return {
-      payuReference: input.payuReference,
-      merchantReference: input.merchantReference ?? input.payuReference,
+      providerReference: ref,
+      payuReference: ref,
+      merchantReference: input.merchantReference ?? ref,
       transactionState: 'SUCCESSFUL',
       transactionType: 'RESERVE',
       status: PaymentStatus.AUTHORIZED,
@@ -86,7 +88,7 @@ export const getTransaction = async (input: GetTransactionInput): Promise<Lookup
       <Api>ONE_ZERO</Api>
       <Safekey>${escapeXml(env.payu.safekey)}</Safekey>
       <AdditionalInformation>
-        <payUReference>${escapeXml(input.payuReference)}</payUReference>
+        <payUReference>${escapeXml(input.payuReference ?? input.providerReference ?? '')}</payUReference>
       </AdditionalInformation>
     </ns1:getTransaction>
   </SOAP-ENV:Body>
@@ -106,8 +108,8 @@ export const getTransaction = async (input: GetTransactionInput): Promise<Lookup
   const transactionState = readTag(soapResponse, 'transactionState') ?? 'FAILED';
   const transactionType = readTag(soapResponse, 'transactionType') ?? '';
   const currentPayuReference = readTag(soapResponse, 'currentPayUReference') ?? '';
-  const payuReference = currentPayuReference || readTag(soapResponse, 'payUReference') || input.payuReference;
-  const merchantReference = readTag(soapResponse, 'merchantReference') ?? input.merchantReference ?? input.payuReference;
+  const payuReference = currentPayuReference || readTag(soapResponse, 'payUReference') || input.payuReference || input.providerReference || '';
+  const merchantReference = readTag(soapResponse, 'merchantReference') ?? input.merchantReference ?? input.payuReference ?? input.providerReference ?? '';
   const resultCode = readTag(soapResponse, 'resultCode') ?? '';
   const resultMessage = readTag(soapResponse, 'resultMessage') ?? '';
   const requestTrace = readTag(soapResponse, 'requestTrace') ?? '';

--- a/src/providers/payu/payu.provider.ts
+++ b/src/providers/payu/payu.provider.ts
@@ -44,7 +44,7 @@ export class PayUProvider extends BaseProvider {
 
   async payment(request: PaymentRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
-    const supportedPaymentMethod = request.paymentMethod ?? DEFAULT_PAYU_METHOD;
+    const supportedPaymentMethod = (request.paymentMethod ?? DEFAULT_PAYU_METHOD) as PayURedirectPaymentMethod;
     const flow = await runPayuPaymentFlow(this.baseUrl, request, supportedPaymentMethod);
 
     const response = this.normalizeResponse({
@@ -68,8 +68,8 @@ export class PayUProvider extends BaseProvider {
   async authorize(request: AuthorizeRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
 
-    const supportedPaymentMethod = request.paymentMethod ?? DEFAULT_PAYU_METHOD;
-    const transactionType: PayUSetTransactionType = request.transactionType ?? 'RESERVE';
+    const supportedPaymentMethod = (request.paymentMethod ?? DEFAULT_PAYU_METHOD) as PayURedirectPaymentMethod;
+    const transactionType: PayUSetTransactionType = (request.transactionType ?? 'RESERVE') as PayUSetTransactionType;
 
     if (shouldUseReserveDoTransaction(request, supportedPaymentMethod, transactionType)) {
       const metadata = request.metadata;

--- a/src/providers/peach/peach.card-management.ts
+++ b/src/providers/peach/peach.card-management.ts
@@ -1,0 +1,64 @@
+import { env } from '../../config/env';
+import { PaymentStatus } from '../../domain/enums';
+import { requestWithRetry } from '../../infrastructure/http.client';
+import { mapPeachStatusWithType } from './peach.status';
+
+interface PeachCardManagementResponse {
+  id?: string;
+  paymentType?: string;
+  amount?: string;
+  currency?: string;
+  result?: { code?: string; description?: string };
+}
+
+export interface PeachCardOperationInput {
+  uniqueTransactionId: string;
+  amount: number;
+  currency: string;
+}
+
+export interface PeachCardOperationResult {
+  providerReference: string;
+  status: PaymentStatus;
+  rawResponse: unknown;
+}
+
+const executeCardOperation = async (
+  input: PeachCardOperationInput,
+  paymentType: 'CP' | 'RV'
+): Promise<PeachCardOperationResult> => {
+  const baseUrl = env.peach.cardApiBaseUrl;
+
+  const body = new URLSearchParams({
+    paymentType,
+    amount: input.amount.toFixed(2),
+    currency: input.currency
+  }).toString();
+
+  const response = await requestWithRetry<PeachCardManagementResponse>({
+    method: 'POST',
+    url: `${baseUrl}/v1/payments/${encodeURIComponent(input.uniqueTransactionId)}`,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${env.peach.cardApiBearerToken}`
+    },
+    data: body
+  });
+
+  const resultCode = response.result?.code ?? '';
+  const providerReference = response.id ?? input.uniqueTransactionId;
+
+  return {
+    providerReference,
+    status: mapPeachStatusWithType(resultCode, paymentType),
+    rawResponse: response
+  };
+};
+
+export const capturePeachPayment = async (input: PeachCardOperationInput): Promise<PeachCardOperationResult> => {
+  return executeCardOperation(input, 'CP');
+};
+
+export const reversePeachPayment = async (input: PeachCardOperationInput): Promise<PeachCardOperationResult> => {
+  return executeCardOperation(input, 'RV');
+};

--- a/src/providers/peach/peach.checkout.ts
+++ b/src/providers/peach/peach.checkout.ts
@@ -1,0 +1,118 @@
+import { randomBytes } from 'crypto';
+import { env } from '../../config/env';
+import { PeachPaymentBrand } from '../../domain/enums';
+import { AuthorizeRequest, PaymentRequest } from '../../domain/provider.interface';
+import { requestWithRetry } from '../../infrastructure/http.client';
+import { generatePeachSignature } from './peach.signature';
+
+export interface PeachCheckoutResult {
+  checkoutId: string;
+  redirectUrl: string;
+  merchantTransactionId: string;
+}
+
+const generateNonce = (): string => randomBytes(16).toString('hex');
+
+export const generateMerchantTransactionId = (paymentId: string): string => {
+  return paymentId.replace(/-/g, '').substring(0, 16);
+};
+
+const setIfString = (params: Record<string, string>, key: string, value: unknown): void => {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    params[key] = value;
+  }
+};
+
+const stringOrDefault = (value: unknown, defaultValue: string): string => {
+  return typeof value === 'string' && value.trim().length > 0 ? value : defaultValue;
+};
+
+const applyBrandSpecificParams = (
+  params: Record<string, string>,
+  paymentBrand: PeachPaymentBrand | undefined,
+  metadata: Record<string, unknown>
+): void => {
+  if (paymentBrand === 'PAYSHAP') {
+    setIfString(params, 'virtualAccount.bank', metadata['virtualAccount.bank']);
+    params['virtualAccount.type'] = stringOrDefault(metadata['virtualAccount.type'], 'CELLPHONE');
+    setIfString(params, 'virtualAccount.accountId', metadata['virtualAccount.accountId']);
+  }
+
+  if (paymentBrand === 'MOBICRED') {
+    setIfString(params, 'virtualAccount.accountId', metadata['virtualAccount.accountId']);
+    setIfString(params, 'virtualAccount.password', metadata['virtualAccount.password']);
+  }
+
+  if (paymentBrand === 'RCSSTORECARDS') {
+    setIfString(params, 'card.number', metadata['card.number']);
+  }
+};
+
+const applyCustomParameters = (params: Record<string, string>, metadata: Record<string, unknown>): void => {
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key.startsWith('customParameters[') && typeof value === 'string') {
+      params[key] = value;
+    }
+  }
+};
+
+const buildCheckoutParams = (
+  request: PaymentRequest | AuthorizeRequest,
+  paymentType: 'DB' | 'PA',
+  merchantTransactionId: string,
+  paymentBrand?: PeachPaymentBrand
+): Record<string, string> => {
+  const params: Record<string, string> = {
+    'authentication.entityId': env.peach.entityId,
+    amount: request.amount.toFixed(2),
+    currency: request.currency,
+    paymentType,
+    merchantTransactionId,
+    nonce: generateNonce(),
+    shopperResultUrl: request.redirectContext?.returnUrl ?? env.peach.defaultShopperResultUrl,
+    notificationUrl: request.redirectContext?.notificationUrl ?? env.peach.defaultNotificationUrl
+  };
+
+  if (paymentBrand) {
+    params.paymentBrand = paymentBrand;
+  }
+
+  if (request.metadata) {
+    applyBrandSpecificParams(params, paymentBrand, request.metadata);
+    applyCustomParameters(params, request.metadata);
+  }
+
+  return params;
+};
+
+export const createPeachCheckout = async (
+  request: PaymentRequest | AuthorizeRequest,
+  paymentType: 'DB' | 'PA',
+  paymentBrand?: PeachPaymentBrand
+): Promise<PeachCheckoutResult> => {
+  const merchantTransactionId = generateMerchantTransactionId(request.paymentId);
+  const params = buildCheckoutParams(request, paymentType, merchantTransactionId, paymentBrand);
+
+  const signature = generatePeachSignature(params, env.peach.secretToken);
+  params.signature = signature;
+
+  const formBody = Object.entries(params)
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&');
+
+  const baseUrl = env.peach.checkoutBaseUrl;
+  const response = await requestWithRetry<Record<string, unknown>>({
+    method: 'POST',
+    url: `${baseUrl}/checkout`,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    data: formBody
+  });
+
+  const checkoutId = String(response.id ?? merchantTransactionId);
+
+  return {
+    checkoutId,
+    redirectUrl: `${baseUrl}/checkout?checkoutId=${encodeURIComponent(checkoutId)}`,
+    merchantTransactionId
+  };
+};

--- a/src/providers/peach/peach.provider.ts
+++ b/src/providers/peach/peach.provider.ts
@@ -1,76 +1,302 @@
-import { randomUUID } from 'crypto';
 import { env } from '../../config/env';
-import { PaymentProviderName, PaymentStatus } from '../../domain/enums';
-import { AuthorizeRequest, CaptureRequest, PaymentRequest, PaymentResponse, RefundRequest, VoidRequest } from '../../domain/provider.interface';
+import { PEACH_CARD_BRANDS, PeachPaymentBrand, PaymentProviderName, PaymentStatus } from '../../domain/enums';
+import {
+  AuthorizeRequest,
+  CaptureRequest,
+  LookupTransactionRequest,
+  LookupTransactionResult,
+  PaymentRequest,
+  PaymentResponse,
+  RefundRequest,
+  VoidRequest,
+  WebhookEvent
+} from '../../domain/provider.interface';
 import { BaseProvider } from '../shared/base.provider';
+import { capturePeachPayment, reversePeachPayment } from './peach.card-management';
+import { createPeachCheckout, generateMerchantTransactionId } from './peach.checkout';
+import { processPeachRefund } from './peach.refund';
+import { executePeachS2SCardPayment, getPeachS2SPaymentStatus, PeachS2SCardInput } from './peach.s2s-payment';
+import { verifyPeachCheckoutSignature } from './peach.signature';
+import { queryPeachTransactionStatus } from './peach.status';
+import { parsePeachWebhook } from './peach.webhook';
+
+const readMetadataString = (metadata: Record<string, unknown> | undefined, key: string): string | undefined => {
+  const value = metadata?.[key];
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+};
+
+const hasS2SCardDetails = (metadata?: Record<string, unknown>): boolean => {
+  if (!metadata) return false;
+  return !!(
+    readMetadataString(metadata, 'card.number') &&
+    readMetadataString(metadata, 'card.expiryMonth') &&
+    readMetadataString(metadata, 'card.expiryYear') &&
+    readMetadataString(metadata, 'card.cvv')
+  );
+};
+
+const buildS2SInput = (
+  request: PaymentRequest | AuthorizeRequest,
+  paymentType: 'DB' | 'PA',
+  paymentBrand: string,
+  merchantTransactionId: string
+): PeachS2SCardInput => {
+  const metadata = request.metadata ?? {};
+  const input: PeachS2SCardInput = {
+    paymentBrand,
+    paymentType,
+    amount: request.amount,
+    currency: request.currency,
+    shopperResultUrl: request.redirectContext?.returnUrl ?? env.peach.defaultShopperResultUrl,
+    merchantTransactionId,
+    card: {
+      number: readMetadataString(metadata, 'card.number')!,
+      holder: readMetadataString(metadata, 'card.holder') ?? '',
+      expiryMonth: readMetadataString(metadata, 'card.expiryMonth')!,
+      expiryYear: readMetadataString(metadata, 'card.expiryYear')!,
+      cvv: readMetadataString(metadata, 'card.cvv')!
+    }
+  };
+
+  const challengeIndicator = readMetadataString(metadata, 'threeDSecure.challengeIndicator');
+  const exemptionFlag = readMetadataString(metadata, 'threeDSecure.exemptionFlag');
+  if (challengeIndicator || exemptionFlag) {
+    input.threeDSecure = { challengeIndicator, exemptionFlag };
+  }
+
+  const browserAcceptHeader = readMetadataString(metadata, 'customer.browser.acceptHeader');
+  if (browserAcceptHeader) {
+    input.browser = {
+      acceptHeader: browserAcceptHeader,
+      language: readMetadataString(metadata, 'customer.browser.language'),
+      screenHeight: readMetadataString(metadata, 'customer.browser.screenHeight'),
+      screenWidth: readMetadataString(metadata, 'customer.browser.screenWidth'),
+      timezone: readMetadataString(metadata, 'customer.browser.timezone'),
+      userAgent: readMetadataString(metadata, 'customer.browser.userAgent'),
+      javaEnabled: readMetadataString(metadata, 'customer.browser.javaEnabled'),
+      javascriptEnabled: readMetadataString(metadata, 'customer.browser.javascriptEnabled'),
+      screenColorDepth: readMetadataString(metadata, 'customer.browser.screenColorDepth'),
+      challengeWindow: readMetadataString(metadata, 'customer.browser.challengeWindow')
+    };
+  }
+
+  input.customerIp = readMetadataString(metadata, 'customer.ip');
+
+  const customParams: Record<string, string> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (key.startsWith('customParameters[') && typeof value === 'string') {
+      const paramName = key.replace(/^customParameters\[/, '').replace(/]$/, '');
+      customParams[paramName] = value;
+    }
+  }
+  if (Object.keys(customParams).length > 0) {
+    input.customParameters = customParams;
+  }
+
+  return input;
+};
 
 export class PeachProvider extends BaseProvider {
+  private readonly merchantTransactionIdMap = new Map<string, string>();
+
   constructor() {
-    super(PaymentProviderName.PEACH, env.peach.baseUrl, env.peach.apiKey, env.peach.webhookSecret);
+    super(PaymentProviderName.PEACH, env.peach.checkoutBaseUrl, '', env.peach.webhookSecret);
   }
 
   async payment(request: PaymentRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+    const paymentBrand = request.paymentMethod as PeachPaymentBrand | undefined;
+    const isCardBrand = paymentBrand && (PEACH_CARD_BRANDS as readonly string[]).includes(paymentBrand);
+
+    if (isCardBrand && hasS2SCardDetails(request.metadata)) {
+      return this.executeS2SCardFlow(request, 'DB', paymentBrand, startedAt, 'payment');
+    }
+
+    const result = await createPeachCheckout(request, 'DB', paymentBrand);
+    this.merchantTransactionIdMap.set(result.merchantTransactionId, request.paymentId);
+
     const response = this.normalizeResponse({
-      providerReference: `peach_${randomUUID()}`,
+      providerReference: result.checkoutId,
       amount: request.amount,
       currency: request.currency,
-      status: PaymentStatus.CAPTURED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/payment` }
+      status: PaymentStatus.PENDING,
+      rawResponse: {
+        checkoutId: result.checkoutId,
+        merchantTransactionId: result.merchantTransactionId,
+        redirectUrl: result.redirectUrl,
+        paymentType: 'DB',
+        endpoint: this.baseUrl
+      }
     });
+
+    response.redirectUrl = result.redirectUrl;
     this.observeLatency('payment', startedAt);
     return response;
   }
 
   async authorize(request: AuthorizeRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+    const paymentBrand = request.paymentMethod as PeachPaymentBrand | undefined;
+    const isCardBrand = paymentBrand && (PEACH_CARD_BRANDS as readonly string[]).includes(paymentBrand);
+    const paymentType = isCardBrand ? ('PA' as const) : ('DB' as const);
+
+    if (isCardBrand && hasS2SCardDetails(request.metadata)) {
+      return this.executeS2SCardFlow(request, paymentType, paymentBrand, startedAt, 'authorize');
+    }
+
+    const result = await createPeachCheckout(request, paymentType, paymentBrand);
+    this.merchantTransactionIdMap.set(result.merchantTransactionId, request.paymentId);
+
     const response = this.normalizeResponse({
-      providerReference: `peach_${randomUUID()}`,
+      providerReference: result.checkoutId,
       amount: request.amount,
       currency: request.currency,
-      status: PaymentStatus.AUTHORIZED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/authorize` }
+      status: PaymentStatus.PENDING,
+      rawResponse: {
+        checkoutId: result.checkoutId,
+        merchantTransactionId: result.merchantTransactionId,
+        redirectUrl: result.redirectUrl,
+        paymentType,
+        endpoint: this.baseUrl
+      }
     });
+
+    response.redirectUrl = result.redirectUrl;
     this.observeLatency('authorize', startedAt);
     return response;
   }
 
   async capture(request: CaptureRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
-    const response = this.normalizeResponse({
-      providerReference: request.transactionId,
-      amount: 0,
-      currency: 'ZAR',
-      status: PaymentStatus.CAPTURED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/capture` }
+
+    const result = await capturePeachPayment({
+      uniqueTransactionId: request.transactionId,
+      amount: request.amount,
+      currency: request.currency
     });
+
+    const response = this.normalizeResponse({
+      providerReference: result.providerReference,
+      amount: request.amount,
+      currency: request.currency,
+      status: result.status,
+      rawResponse: result.rawResponse
+    });
+
     this.observeLatency('capture', startedAt);
     return response;
   }
 
   async refund(request: RefundRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+
+    const result = await processPeachRefund({
+      uniqueTransactionId: request.transactionId,
+      amount: request.amount,
+      currency: request.currency
+    });
+
     const response = this.normalizeResponse({
-      providerReference: request.transactionId,
+      providerReference: result.providerReference,
       amount: request.amount,
       currency: request.currency,
-      status: PaymentStatus.REFUNDED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/refund` }
+      status: result.status,
+      rawResponse: result.rawResponse
     });
+
     this.observeLatency('refund', startedAt);
     return response;
   }
 
   async void(request: VoidRequest): Promise<PaymentResponse> {
     const startedAt = Date.now();
+
+    const result = await reversePeachPayment({
+      uniqueTransactionId: request.transactionId,
+      amount: request.amount,
+      currency: request.currency
+    });
+
     const response = this.normalizeResponse({
-      providerReference: request.transactionId,
+      providerReference: result.providerReference,
       amount: request.amount,
       currency: request.currency,
-      status: PaymentStatus.VOIDED,
-      rawResponse: { simulated: true, endpoint: `${this.baseUrl}/void` }
+      status: result.status,
+      rawResponse: result.rawResponse
     });
+
     this.observeLatency('void', startedAt);
+    return response;
+  }
+
+  verifyWebhookSignature(payload: string, signature: string): boolean {
+    if (signature) {
+      return super.verifyWebhookSignature(payload, signature);
+    }
+    return verifyPeachCheckoutSignature(payload, env.peach.secretToken);
+  }
+
+  async handleWebhook(payload: unknown): Promise<WebhookEvent | null> {
+    return parsePeachWebhook(payload, this.merchantTransactionIdMap);
+  }
+
+  async lookupTransaction(request: LookupTransactionRequest): Promise<LookupTransactionResult> {
+    if (request.providerReference && request.providerReference.length > 16) {
+      const s2sResult = await getPeachS2SPaymentStatus(request.providerReference);
+      const raw = (s2sResult.rawResponse ?? {}) as Record<string, unknown>;
+      return {
+        providerReference: s2sResult.providerReference,
+        merchantReference: (raw.merchantTransactionId as string) ?? request.merchantReference ?? '',
+        transactionState: s2sResult.status,
+        transactionType: (raw.paymentType as string) ?? '',
+        status: s2sResult.status,
+        amountInCents: Math.round(parseFloat((raw.amount as string) ?? '0') * 100),
+        currency: (raw.currency as string) ?? '',
+        resultCode: ((raw.result as Record<string, unknown>)?.code as string) ?? '',
+        resultMessage: ((raw.result as Record<string, unknown>)?.description as string) ?? '',
+        rawResponse: s2sResult.rawResponse
+      };
+    }
+
+    const merchantTransactionId = request.merchantReference
+      ? generateMerchantTransactionId(request.merchantReference)
+      : (request.providerReference ?? '');
+
+    return queryPeachTransactionStatus(merchantTransactionId);
+  }
+
+  private async executeS2SCardFlow(
+    request: PaymentRequest | AuthorizeRequest,
+    paymentType: 'DB' | 'PA',
+    paymentBrand: string,
+    startedAt: number,
+    operation: string
+  ): Promise<PaymentResponse> {
+    const merchantTransactionId = generateMerchantTransactionId(request.paymentId);
+    this.merchantTransactionIdMap.set(merchantTransactionId, request.paymentId);
+
+    const s2sInput = buildS2SInput(request, paymentType, paymentBrand, merchantTransactionId);
+    const result = await executePeachS2SCardPayment(s2sInput);
+
+    const response = this.normalizeResponse({
+      providerReference: result.providerReference,
+      amount: request.amount,
+      currency: request.currency,
+      status: result.status,
+      rawResponse: {
+        ...(result.rawResponse as Record<string, unknown>),
+        merchantTransactionId,
+        paymentType,
+        flowType: 'SERVER_TO_SERVER',
+        endpoint: env.peach.cardApiBaseUrl
+      }
+    });
+
+    if (result.status === PaymentStatus.PENDING_3DS && result.redirectUrl) {
+      response.redirectUrl = result.redirectUrl;
+    }
+
+    this.observeLatency(operation, startedAt);
     return response;
   }
 }

--- a/src/providers/peach/peach.refund.ts
+++ b/src/providers/peach/peach.refund.ts
@@ -1,0 +1,53 @@
+import { PaymentStatus } from '../../domain/enums';
+import { env } from '../../config/env';
+import { requestWithRetry } from '../../infrastructure/http.client';
+import { mapPeachStatusWithType } from './peach.status';
+
+interface PeachRefundResponse {
+  id?: string;
+  paymentType?: string;
+  amount?: string;
+  currency?: string;
+  result?: { code?: string; description?: string };
+}
+
+export interface PeachRefundInput {
+  uniqueTransactionId: string;
+  amount: number;
+  currency: string;
+}
+
+export interface PeachRefundResult {
+  providerReference: string;
+  status: PaymentStatus;
+  rawResponse: unknown;
+}
+
+export const processPeachRefund = async (input: PeachRefundInput): Promise<PeachRefundResult> => {
+  const baseUrl = env.peach.paymentsApiBaseUrl;
+
+  const body = new URLSearchParams({
+    'authentication.userId': env.peach.paymentsApiUserId,
+    'authentication.password': env.peach.paymentsApiPassword,
+    'authentication.entityId': env.peach.paymentsApiEntityId,
+    paymentType: 'RF',
+    amount: input.amount.toFixed(2),
+    currency: input.currency
+  }).toString();
+
+  const response = await requestWithRetry<PeachRefundResponse>({
+    method: 'POST',
+    url: `${baseUrl}/payments/${encodeURIComponent(input.uniqueTransactionId)}`,
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    data: body
+  });
+
+  const resultCode = response.result?.code ?? '';
+  const providerReference = response.id ?? input.uniqueTransactionId;
+
+  return {
+    providerReference,
+    status: mapPeachStatusWithType(resultCode, 'RF'),
+    rawResponse: response
+  };
+};

--- a/src/providers/peach/peach.s2s-payment.ts
+++ b/src/providers/peach/peach.s2s-payment.ts
@@ -1,0 +1,184 @@
+import { env } from '../../config/env';
+import { PaymentStatus } from '../../domain/enums';
+import { requestWithRetry } from '../../infrastructure/http.client';
+import { mapPeachStatusWithType } from './peach.status';
+
+export interface PeachS2SCardInput {
+  paymentBrand: string;
+  paymentType: 'DB' | 'PA';
+  amount: number;
+  currency: string;
+  shopperResultUrl: string;
+  card: {
+    number: string;
+    holder: string;
+    expiryMonth: string;
+    expiryYear: string;
+    cvv: string;
+  };
+  merchantTransactionId?: string;
+  threeDSecure?: {
+    challengeIndicator?: string;
+    exemptionFlag?: string;
+  };
+  browser?: {
+    acceptHeader?: string;
+    language?: string;
+    screenHeight?: string;
+    screenWidth?: string;
+    timezone?: string;
+    userAgent?: string;
+    javaEnabled?: string;
+    javascriptEnabled?: string;
+    screenColorDepth?: string;
+    challengeWindow?: string;
+  };
+  customerIp?: string;
+  customParameters?: Record<string, string>;
+}
+
+interface PeachS2SRedirect {
+  url?: string;
+  method?: string;
+  parameters?: { name: string; value: string }[];
+}
+
+interface PeachS2SResponse {
+  id?: string;
+  paymentType?: string;
+  paymentBrand?: string;
+  amount?: string;
+  currency?: string;
+  result?: { code?: string; description?: string };
+  redirect?: PeachS2SRedirect;
+  threeDSecure?: Record<string, unknown>;
+  card?: Record<string, unknown>;
+  customParameters?: Record<string, string>;
+}
+
+export interface PeachS2SPaymentResult {
+  providerReference: string;
+  status: PaymentStatus;
+  redirectUrl?: string;
+  redirectMethod?: string;
+  redirectParameters?: { name: string; value: string }[];
+  rawResponse: unknown;
+}
+
+const buildFormParams = (input: PeachS2SCardInput): URLSearchParams => {
+  const params = new URLSearchParams();
+  params.append('entityId', env.peach.cardApiEntityId || env.peach.entityId);
+  params.append('amount', input.amount.toFixed(2));
+  params.append('currency', input.currency);
+  params.append('paymentBrand', input.paymentBrand);
+  params.append('paymentType', input.paymentType);
+
+  params.append('card.number', input.card.number);
+  params.append('card.holder', input.card.holder);
+  params.append('card.expiryMonth', input.card.expiryMonth);
+  params.append('card.expiryYear', input.card.expiryYear);
+  params.append('card.cvv', input.card.cvv);
+
+  params.append('shopperResultUrl', input.shopperResultUrl);
+
+  if (input.merchantTransactionId) {
+    params.append('merchantTransactionId', input.merchantTransactionId);
+  }
+
+  if (input.threeDSecure?.challengeIndicator) {
+    params.append('threeDSecure.challengeIndicator', input.threeDSecure.challengeIndicator);
+  }
+  if (input.threeDSecure?.exemptionFlag) {
+    params.append('threeDSecure.exemptionFlag', input.threeDSecure.exemptionFlag);
+  }
+
+  if (input.browser) {
+    const b = input.browser;
+    if (b.acceptHeader) params.append('customer.browser.acceptHeader', b.acceptHeader);
+    if (b.language) params.append('customer.browser.language', b.language);
+    if (b.screenHeight) params.append('customer.browser.screenHeight', b.screenHeight);
+    if (b.screenWidth) params.append('customer.browser.screenWidth', b.screenWidth);
+    if (b.timezone) params.append('customer.browser.timezone', b.timezone);
+    if (b.userAgent) params.append('customer.browser.userAgent', b.userAgent);
+    if (b.javaEnabled) params.append('customer.browser.javaEnabled', b.javaEnabled);
+    if (b.javascriptEnabled) params.append('customer.browser.javascriptEnabled', b.javascriptEnabled);
+    if (b.screenColorDepth) params.append('customer.browser.screenColorDepth', b.screenColorDepth);
+    if (b.challengeWindow) params.append('customer.browser.challengeWindow', b.challengeWindow);
+  }
+
+  if (input.customerIp) {
+    params.append('customer.ip', input.customerIp);
+  }
+
+  if (input.customParameters) {
+    for (const [key, value] of Object.entries(input.customParameters)) {
+      params.append(`customParameters[${key}]`, value);
+    }
+  }
+
+  return params;
+};
+
+const isPending3DS = (response: PeachS2SResponse): boolean => {
+  return !!response.redirect?.url;
+};
+
+export const executePeachS2SCardPayment = async (
+  input: PeachS2SCardInput
+): Promise<PeachS2SPaymentResult> => {
+  const baseUrl = env.peach.cardApiBaseUrl;
+  const params = buildFormParams(input);
+
+  const response = await requestWithRetry<PeachS2SResponse>({
+    method: 'POST',
+    url: `${baseUrl}/v1/payments`,
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Authorization: `Bearer ${env.peach.cardApiBearerToken}`
+    },
+    data: params.toString()
+  });
+
+  const resultCode = response.result?.code ?? '';
+  const providerReference = response.id ?? '';
+
+  if (isPending3DS(response)) {
+    return {
+      providerReference,
+      status: PaymentStatus.PENDING_3DS,
+      redirectUrl: response.redirect!.url,
+      redirectMethod: response.redirect!.method ?? 'POST',
+      redirectParameters: response.redirect!.parameters,
+      rawResponse: response
+    };
+  }
+
+  return {
+    providerReference,
+    status: mapPeachStatusWithType(resultCode, input.paymentType),
+    rawResponse: response
+  };
+};
+
+export const getPeachS2SPaymentStatus = async (
+  paymentId: string
+): Promise<PeachS2SPaymentResult> => {
+  const baseUrl = env.peach.cardApiBaseUrl;
+
+  const response = await requestWithRetry<PeachS2SResponse>({
+    method: 'GET',
+    url: `${baseUrl}/v1/payments/${encodeURIComponent(paymentId)}?entityId=${encodeURIComponent(env.peach.cardApiEntityId || env.peach.entityId)}`,
+    headers: {
+      Authorization: `Bearer ${env.peach.cardApiBearerToken}`
+    }
+  });
+
+  const resultCode = response.result?.code ?? '';
+  const paymentType = response.paymentType ?? 'DB';
+
+  return {
+    providerReference: response.id ?? paymentId,
+    status: mapPeachStatusWithType(resultCode, paymentType),
+    rawResponse: response
+  };
+};

--- a/src/providers/peach/peach.signature.ts
+++ b/src/providers/peach/peach.signature.ts
@@ -1,0 +1,38 @@
+import { createHmac } from 'crypto';
+
+export const generatePeachSignature = (params: Record<string, string>, secretToken: string): string => {
+  const sortedKeys = Object.keys(params).sort();
+  const dataToSign = sortedKeys.map((key) => `${key}${params[key]}`).join('');
+  return createHmac('sha256', secretToken).update(dataToSign).digest('hex');
+};
+
+const parseFormBody = (body: string): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const pair of body.split('&')) {
+    const eqIndex = pair.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = decodeURIComponent(pair.substring(0, eqIndex));
+    const value = decodeURIComponent(pair.substring(eqIndex + 1));
+    result[key] = value;
+  }
+  return result;
+};
+
+export const verifyPeachCheckoutSignature = (formBody: string, secretToken: string): boolean => {
+  const params = parseFormBody(formBody);
+  const receivedSignature = params.signature;
+
+  if (!receivedSignature) {
+    return false;
+  }
+
+  const paramsWithoutSignature: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    if (key !== 'signature') {
+      paramsWithoutSignature[key] = value;
+    }
+  }
+
+  const expected = generatePeachSignature(paramsWithoutSignature, secretToken);
+  return expected === receivedSignature;
+};

--- a/src/providers/peach/peach.status.ts
+++ b/src/providers/peach/peach.status.ts
@@ -1,0 +1,90 @@
+import { PaymentStatus } from '../../domain/enums';
+import { LookupTransactionResult } from '../../domain/provider.interface';
+import { env } from '../../config/env';
+import { requestWithRetry } from '../../infrastructure/http.client';
+import { generatePeachSignature } from './peach.signature';
+
+export const mapPeachStatusWithType = (resultCode: string, paymentType: string): PaymentStatus => {
+  if (!resultCode) return PaymentStatus.UNKNOWN;
+
+  const isSuccess = resultCode.startsWith('000.0') || resultCode.startsWith('000.1');
+  const isPending = resultCode.startsWith('000.2');
+
+  if (isPending) return PaymentStatus.PENDING;
+  if (!isSuccess) return PaymentStatus.FAILED;
+
+  switch (paymentType) {
+    case 'PA':
+      return PaymentStatus.AUTHORIZED;
+    case 'DB':
+      return PaymentStatus.CAPTURED;
+    case 'RF':
+      return PaymentStatus.REFUNDED;
+    case 'CP':
+      return PaymentStatus.CAPTURED;
+    case 'RV':
+      return PaymentStatus.VOIDED;
+    default:
+      return PaymentStatus.CAPTURED;
+  }
+};
+
+interface PeachStatusPayment {
+  id?: string;
+  paymentType?: string;
+  paymentBrand?: string;
+  amount?: string;
+  currency?: string;
+  result?: { code?: string; description?: string };
+}
+
+interface PeachStatusResponse {
+  id?: string;
+  amount?: string;
+  currency?: string;
+  paymentType?: string;
+  paymentBrand?: string;
+  merchantTransactionId?: string;
+  result?: { code?: string; description?: string };
+  payments?: PeachStatusPayment[];
+}
+
+export const queryPeachTransactionStatus = async (merchantTransactionId: string): Promise<LookupTransactionResult> => {
+  const baseUrl = env.peach.checkoutBaseUrl;
+  const entityId = env.peach.entityId;
+  const secretToken = env.peach.secretToken;
+
+  const params: Record<string, string> = {
+    'authentication.entityId': entityId,
+    merchantTransactionId
+  };
+
+  const signature = generatePeachSignature(params, secretToken);
+  const queryString = new URLSearchParams({ ...params, signature }).toString();
+
+  const response = await requestWithRetry<PeachStatusResponse>({
+    method: 'GET',
+    url: `${baseUrl}/status?${queryString}`
+  });
+
+  const lastPayment = response.payments?.[response.payments.length - 1];
+  const resultCode = lastPayment?.result?.code ?? response.result?.code ?? '';
+  const resultMessage = lastPayment?.result?.description ?? response.result?.description ?? '';
+  const paymentType = lastPayment?.paymentType ?? response.paymentType ?? 'DB';
+  const providerReference = lastPayment?.id ?? response.id ?? '';
+  const amountStr = lastPayment?.amount ?? response.amount ?? '0';
+  const currency = lastPayment?.currency ?? response.currency ?? 'ZAR';
+
+  return {
+    providerReference,
+    merchantReference: merchantTransactionId,
+    transactionState: resultCode,
+    transactionType: paymentType,
+    status: mapPeachStatusWithType(resultCode, paymentType),
+    amountInCents: Math.round(parseFloat(amountStr) * 100),
+    currency,
+    resultCode,
+    resultMessage,
+    rawResponse: response
+  };
+};

--- a/src/providers/peach/peach.webhook.ts
+++ b/src/providers/peach/peach.webhook.ts
@@ -1,0 +1,86 @@
+import { WebhookEvent } from '../../domain/provider.interface';
+import { mapPeachStatusWithType } from './peach.status';
+
+const parseFormBody = (body: string): Record<string, string> => {
+  const result: Record<string, string> = {};
+  for (const pair of body.split('&')) {
+    const eqIndex = pair.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = decodeURIComponent(pair.substring(0, eqIndex));
+    const value = decodeURIComponent(pair.substring(eqIndex + 1));
+    result[key] = value;
+  }
+  return result;
+};
+
+interface ParsedWebhookFields {
+  merchantTransactionId?: string;
+  id?: string;
+  paymentType?: string;
+  resultCode?: string;
+}
+
+const asString = (value: unknown): string | undefined => {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+};
+
+const extractFromJson = (json: Record<string, unknown>): ParsedWebhookFields => {
+  const result = json.result as Record<string, unknown> | undefined;
+  return {
+    merchantTransactionId: asString(json.merchantTransactionId),
+    id: asString(json.id),
+    paymentType: asString(json.paymentType),
+    resultCode: asString(result?.code)
+  };
+};
+
+const extractWebhookFields = (payload: unknown): ParsedWebhookFields => {
+  if (typeof payload === 'string') {
+    if (payload.includes('=') && !payload.startsWith('{')) {
+      const params = parseFormBody(payload);
+      return {
+        merchantTransactionId: params.merchantTransactionId,
+        id: params.id,
+        paymentType: params.paymentType,
+        resultCode: params['result.code']
+      };
+    }
+
+    try {
+      const json = JSON.parse(payload) as Record<string, unknown>;
+      return extractFromJson(json);
+    } catch {
+      return {};
+    }
+  }
+
+  if (payload && typeof payload === 'object') {
+    return extractFromJson(payload as Record<string, unknown>);
+  }
+
+  return {};
+};
+
+export const parsePeachWebhook = (
+  payload: unknown,
+  merchantTransactionIdMap: Map<string, string>
+): WebhookEvent | null => {
+  const fields = extractWebhookFields(payload);
+
+  if (!fields.merchantTransactionId) {
+    return null;
+  }
+
+  const resultCode = fields.resultCode ?? '';
+  const paymentType = fields.paymentType ?? 'DB';
+  const status = mapPeachStatusWithType(resultCode, paymentType);
+
+  const fullPaymentId = merchantTransactionIdMap.get(fields.merchantTransactionId);
+
+  return {
+    merchantReference: fullPaymentId ?? fields.merchantTransactionId,
+    providerReference: fields.id,
+    status,
+    rawPayload: payload
+  };
+};

--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'crypto';
-import { PayURedirectPaymentMethod, PayUSetTransactionType, PaymentProviderName, PaymentStatus } from '../domain/enums';
+import { PaymentProviderName, PaymentStatus } from '../domain/enums';
 import { ensureTransition, Payment } from '../domain/payment.entity';
 import { LookupTransactionResult, PaymentProvider, PaymentResponse, RedirectContext } from '../domain/provider.interface';
 import { ProviderOperationError } from '../errors/provider-operation.error';
@@ -22,8 +22,8 @@ export interface CreatePaymentInput {
   currency: string;
   idempotencyKey: string;
   customerReference?: string;
-  paymentMethod?: PayURedirectPaymentMethod;
-  transactionType?: PayUSetTransactionType;
+  paymentMethod?: string;
+  transactionType?: string;
   redirectContext?: RedirectContext;
   metadata?: Record<string, unknown>;
 }
@@ -234,12 +234,20 @@ export class PaymentService {
     return payment;
   }
 
-  async getPayment(paymentId: string): Promise<Payment | null> {
-    return this.paymentRepository.findById(paymentId);
+  async getPayment(paymentId: string, headers: Record<string, string | string[] | undefined> = {}): Promise<Payment | null> {
+    const payment = await this.paymentRepository.findById(paymentId);
+    if (!payment) {
+      return null;
+    }
+
+    await this.refreshPaymentFromProvider(payment, headers, 'payment-read');
+    return payment;
   }
 
-  async listTransactions(): Promise<Payment[]> {
-    return this.paymentRepository.listAll();
+  async listTransactions(headers: Record<string, string | string[] | undefined> = {}): Promise<Payment[]> {
+    const payments = await this.paymentRepository.listAll();
+    await Promise.all(payments.map((payment) => this.refreshPaymentFromProvider(payment, headers, 'transactions-read')));
+    return payments;
   }
 
   async listTransactionLogs(paymentId: string): Promise<PaymentLog[]> {
@@ -252,43 +260,10 @@ export class PaymentService {
     headers: Record<string, string | string[] | undefined>
   ): Promise<LookupTransactionResult> {
     const payment = await this.getExistingPayment(paymentId);
-    if (!payment.providerReference) {
-      throw new Error(`No provider reference for payment: ${paymentId}`);
-    }
-
-    const provider = this.providers[payment.provider];
-    if (!provider.lookupTransaction) {
+    const result = await this.refreshPaymentFromProvider(payment, headers, 'provider-status-lookup', true);
+    if (!result) {
       throw new Error(`Provider ${payment.provider} does not support transaction lookup`);
     }
-
-    const startedAt = Date.now();
-    const result = await provider.lookupTransaction({
-      payuReference: payment.providerReference,
-      merchantReference: payment.id
-    });
-
-    if (result.payuReference && payment.providerReference !== result.payuReference) {
-      payment.providerReference = result.payuReference;
-    }
-
-    if (payment.status !== result.status) {
-      ensureTransition(payment.status, result.status);
-      payment.status = result.status;
-    }
-
-    payment.updatedAt = new Date();
-    await this.paymentRepository.update(payment);
-
-    await this.paymentLogRepository.create({
-      id: randomUUID(),
-      paymentId: payment.id,
-      provider: payment.provider,
-      request: { paymentId: payment.id, operation: 'provider-status-lookup', providerReference: payment.providerReference },
-      response: result,
-      headers,
-      responseTimeMs: Date.now() - startedAt,
-      createdAt: new Date()
-    });
 
     return result;
   }
@@ -333,6 +308,71 @@ export class PaymentService {
       throw new Error(`Payment not found: ${paymentId}`);
     }
     return payment;
+  }
+
+  private async refreshPaymentFromProvider(
+    payment: Payment,
+    headers: Record<string, string | string[] | undefined>,
+    operation: 'provider-status-lookup' | 'payment-read' | 'transactions-read',
+    requireLookup = false
+  ): Promise<LookupTransactionResult | null> {
+    if (!payment.providerReference) {
+      if (requireLookup) {
+        throw new Error(`No provider reference for payment: ${payment.id}`);
+      }
+      return null;
+    }
+
+    const provider = this.providers[payment.provider];
+    if (!provider.lookupTransaction) {
+      if (requireLookup) {
+        throw new Error(`Provider ${payment.provider} does not support transaction lookup`);
+      }
+      return null;
+    }
+
+    const startedAt = Date.now();
+    const result = await provider.lookupTransaction({
+      providerReference: payment.providerReference,
+      payuReference: payment.providerReference,
+      merchantReference: payment.id
+    });
+
+    const latestProviderReference = result.providerReference ?? result.payuReference;
+    if (latestProviderReference && payment.providerReference !== latestProviderReference) {
+      payment.providerReference = latestProviderReference;
+    }
+
+    if (payment.status !== result.status) {
+      try {
+        ensureTransition(payment.status, result.status);
+        payment.status = result.status;
+      } catch {
+        logger.warn('Ignoring stale provider lookup state during read refresh', {
+          paymentId: payment.id,
+          provider: payment.provider,
+          currentStatus: payment.status,
+          lookupStatus: result.status,
+          operation
+        });
+      }
+    }
+
+    payment.updatedAt = new Date();
+    await this.paymentRepository.update(payment);
+
+    await this.paymentLogRepository.create({
+      id: randomUUID(),
+      paymentId: payment.id,
+      provider: payment.provider,
+      request: { paymentId: payment.id, operation, providerReference: payment.providerReference },
+      response: result,
+      headers,
+      responseTimeMs: Date.now() - startedAt,
+      createdAt: new Date()
+    });
+
+    return result;
   }
 
   private applyOperationResult(

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,18 +1,28 @@
 import { z } from 'zod';
-import { PaymentProviderName, PAYU_REDIRECT_PAYMENT_METHODS, PAYU_SET_TRANSACTION_TYPES } from '../domain/enums';
+import { PaymentProviderName, PAYU_REDIRECT_PAYMENT_METHODS, PAYU_SET_TRANSACTION_TYPES, PEACH_PAYMENT_BRANDS, PEACH_PAYMENT_TYPES } from '../domain/enums';
 
-const payuMethodSchema = z.enum(PAYU_REDIRECT_PAYMENT_METHODS);
-const payuTransactionTypeSchema = z.enum(PAYU_SET_TRANSACTION_TYPES);
+const paymentMethodSchema = z.union([
+  z.enum(PAYU_REDIRECT_PAYMENT_METHODS),
+  z.enum(PEACH_PAYMENT_BRANDS)
+]);
+const transactionTypeSchema = z.union([
+  z.enum(PAYU_SET_TRANSACTION_TYPES),
+  z.enum(PEACH_PAYMENT_TYPES)
+]);
 const redirectChannelSchema = z.enum(['web', 'responsive', 'mobi']);
 const paymentMetadataSchema = z.record(z.unknown());
 
-const getMissingPayflexFields = (metadata: Record<string, unknown> | undefined): string[] => {
-  const requiredFields = ['firstName', 'lastName', 'mobile', 'email'] as const;
+const payflexRequiredFieldAliases = [
+  { label: 'firstName', keys: ['firstName', 'givenNames'] },
+  { label: 'lastName', keys: ['lastName', 'surname'] },
+  { label: 'mobile', keys: ['mobile', 'phoneNumber'] },
+  { label: 'email', keys: ['email'] }
+] as const;
 
-  return requiredFields.filter((field) => {
-    const value = metadata?.[field];
-    return typeof value !== 'string' || value.trim().length === 0;
-  });
+const getMissingPayflexFields = (metadata: Record<string, unknown> | undefined): string[] => {
+  return payflexRequiredFieldAliases
+    .filter(({ keys }) => !keys.some((key) => typeof metadata?.[key] === 'string' && metadata[key].trim().length > 0))
+    .map(({ label }) => label);
 };
 
 const getMissingS2SCardFields = (metadata: Record<string, unknown> | undefined): string[] => {
@@ -30,8 +40,8 @@ export const createPaymentSchema = z
     amount: z.number().positive(),
     currency: z.string().min(3).max(3).transform((value) => value.toUpperCase()),
     customerReference: z.string().optional(),
-    paymentMethod: payuMethodSchema.optional(),
-    transactionType: payuTransactionTypeSchema.optional(),
+    paymentMethod: paymentMethodSchema.optional(),
+    transactionType: transactionTypeSchema.optional(),
     redirectContext: z
       .object({
         returnUrl: z.string().url().optional(),
@@ -51,6 +61,37 @@ export const createPaymentSchema = z
           path: ['metadata'],
           message: `PAYFLEX requires metadata fields: ${missingFields.join(', ')}`
         });
+      }
+    }
+
+    if (value.provider === PaymentProviderName.PEACH) {
+      if (value.paymentMethod === 'PAYSHAP' && value.metadata) {
+        const bank = value.metadata['virtualAccount.bank'];
+        const accountId = value.metadata['virtualAccount.accountId'];
+        if (typeof bank !== 'string' || bank.trim().length === 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, path: ['metadata'], message: 'PAYSHAP requires metadata field: virtualAccount.bank' });
+        }
+        if (typeof accountId !== 'string' || accountId.trim().length === 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, path: ['metadata'], message: 'PAYSHAP requires metadata field: virtualAccount.accountId' });
+        }
+      }
+
+      if (value.paymentMethod === 'MOBICRED' && value.metadata) {
+        const accountId = value.metadata['virtualAccount.accountId'];
+        const password = value.metadata['virtualAccount.password'];
+        if (typeof accountId !== 'string' || accountId.trim().length === 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, path: ['metadata'], message: 'MOBICRED requires metadata field: virtualAccount.accountId' });
+        }
+        if (typeof password !== 'string' || password.trim().length === 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, path: ['metadata'], message: 'MOBICRED requires metadata field: virtualAccount.password' });
+        }
+      }
+
+      if (value.paymentMethod === 'RCSSTORECARDS' && value.metadata) {
+        const cardNumber = value.metadata['card.number'];
+        if (typeof cardNumber !== 'string' || cardNumber.trim().length === 0) {
+          context.addIssue({ code: z.ZodIssueCode.custom, path: ['metadata'], message: 'RCSSTORECARDS requires metadata field: card.number' });
+        }
       }
     }
 

--- a/tests/integration/payments.routes.test.ts
+++ b/tests/integration/payments.routes.test.ts
@@ -184,13 +184,25 @@ describe('Payments API', () => {
       .send({
         provider: 'PAYFLEX',
         amount: 199,
-        currency: 'ZAR'
+        currency: 'ZAR',
+        redirectContext: {
+          returnUrl: 'https://merchant.example.com/payflex/confirm',
+          cancelUrl: 'https://merchant.example.com/payflex/cancel',
+          notificationUrl: 'https://merchant.example.com/webhooks/payflex'
+        },
+        metadata: {
+          firstName: 'Sipho',
+          lastName: 'Mthembu',
+          email: 'payflextest+provider@gmail.com',
+          mobile: '0123456789'
+        }
       });
 
     expect(res.status).toBe(201);
     expect(res.body.provider).toBe('PAYFLEX');
-    expect(res.body.status).toBe('AUTHORIZED');
-    expect(res.body.providerReference).toContain('payflex_');
+    expect(res.body.status).toBe('PENDING');
+    expect(res.body.providerReference).toMatch(/[0-9a-f-]{36}/i);
+    expect(res.body.redirectUrl).toContain('checkout.payflex');
   });
 
   it('updates payment status to captured after successful payu ipn', async () => {
@@ -249,6 +261,26 @@ describe('Payments API', () => {
 
     expect(lookup.status).toBe(200);
     expect(lookup.body.status).toBe('AUTHORIZED');
+
+    const payment = await request(app).get(`/payments/${created.body.id}`);
+
+    expect(payment.status).toBe(200);
+    expect(payment.body.status).toBe('AUTHORIZED');
+  });
+
+  it('refreshes provider state when fetching a payment by id', async () => {
+    const created = await request(app)
+      .post('/payments')
+      .set('idempotency-key', 'idem-provider-refresh-get')
+      .send({
+        provider: 'PAYU',
+        amount: 120,
+        currency: 'ZAR',
+        transactionType: 'PAYMENT'
+      });
+
+    expect(created.status).toBe(201);
+    expect(created.body.status).toBe('PENDING');
 
     const payment = await request(app).get(`/payments/${created.body.id}`);
 

--- a/tests/integration/webhooks.routes.test.ts
+++ b/tests/integration/webhooks.routes.test.ts
@@ -30,7 +30,12 @@ describe('Webhook API', () => {
   });
 
   it('accepts valid signed payflex webhook', async () => {
-    const payload = JSON.stringify({ event: 'payment.updated' });
+    const payload = JSON.stringify({
+      orderId: 'order-1',
+      orderStatus: 'Approved',
+      merchantReference: 'merchant-1',
+      amount: 100
+    });
     const signature = createHmac('sha256', 'payflex_dev_secret').update(payload).digest('hex');
 
     const res = await request(app)

--- a/tests/providers/peach.provider.test.ts
+++ b/tests/providers/peach.provider.test.ts
@@ -1,0 +1,272 @@
+import { PaymentStatus, PEACH_PAYMENT_BRANDS } from '../../src/domain/enums';
+import { PeachProvider } from '../../src/providers/peach/peach.provider';
+import { generateMerchantTransactionId } from '../../src/providers/peach/peach.checkout';
+
+jest.mock('../../src/infrastructure/http.client', () => ({
+  requestWithRetry: jest.fn()
+}));
+
+import { requestWithRetry } from '../../src/infrastructure/http.client';
+
+const mockRequestWithRetry = requestWithRetry as jest.MockedFunction<typeof requestWithRetry>;
+
+describe('PeachProvider', () => {
+  let provider: PeachProvider;
+
+  beforeEach(() => {
+    provider = new PeachProvider();
+    mockRequestWithRetry.mockReset();
+  });
+
+  describe('generateMerchantTransactionId', () => {
+    it('generates a 16-char hex ID from a UUID', () => {
+      const id = generateMerchantTransactionId('a1b2c3d4-e5f6-7890-abcd-ef1234567890');
+      expect(id).toBe('a1b2c3d4e5f67890');
+      expect(id).toHaveLength(16);
+    });
+
+    it('is deterministic', () => {
+      const uuid = '12345678-1234-1234-1234-123456789012';
+      expect(generateMerchantTransactionId(uuid)).toBe(generateMerchantTransactionId(uuid));
+    });
+  });
+
+  describe('payment', () => {
+    it('creates a checkout with DB payment type and returns redirect URL', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_abc123' });
+
+      const result = await provider.payment({
+        paymentId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        amount: 250,
+        currency: 'ZAR'
+      });
+
+      expect(result.provider).toBe('PEACH');
+      expect(result.status).toBe(PaymentStatus.PENDING);
+      expect(result.amount).toBe(250);
+      expect(result.currency).toBe('ZAR');
+      expect(result.providerReference).toBe('checkout_abc123');
+      expect(result.redirectUrl).toContain('checkoutId=checkout_abc123');
+
+      expect(mockRequestWithRetry).toHaveBeenCalledTimes(1);
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.method).toBe('POST');
+      expect((callArgs.url as string)).toContain('/checkout');
+      expect((callArgs.data as string)).toContain('paymentType=DB');
+    });
+
+    it('includes paymentBrand when specified', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_visa1' });
+
+      await provider.payment({
+        paymentId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+        amount: 100,
+        currency: 'ZAR',
+        paymentMethod: 'VISA'
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.data as string)).toContain('paymentBrand=VISA');
+    });
+  });
+
+  describe('authorize', () => {
+    it('uses PA payment type for card brands', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_pa1' });
+
+      const result = await provider.authorize({
+        paymentId: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
+        amount: 500,
+        currency: 'ZAR',
+        paymentMethod: 'VISA'
+      });
+
+      expect(result.status).toBe(PaymentStatus.PENDING);
+      expect(result.redirectUrl).toContain('checkoutId=checkout_pa1');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.data as string)).toContain('paymentType=PA');
+    });
+
+    it('uses DB payment type for non-card brands', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_db1' });
+
+      await provider.authorize({
+        paymentId: 'd4e5f6a7-b8c9-0123-defa-234567890123',
+        amount: 300,
+        currency: 'ZAR',
+        paymentMethod: 'PAYBYBANK'
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.data as string)).toContain('paymentType=DB');
+    });
+
+    it.each(['VISA', 'MASTER', 'AMEX', 'DINERS'] as const)('uses PA for card brand %s', async (brand) => {
+      mockRequestWithRetry.mockResolvedValue({ id: `checkout_${brand}` });
+
+      await provider.authorize({
+        paymentId: 'e5f6a7b8-c9d0-1234-efab-345678901234',
+        amount: 100,
+        currency: 'ZAR',
+        paymentMethod: brand
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.data as string)).toContain('paymentType=PA');
+    });
+  });
+
+  describe('capture', () => {
+    it('calls card management API with CP payment type', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'capture_result_001',
+        result: { code: '000.100.110', description: 'Success' }
+      });
+
+      const result = await provider.capture({
+        transactionId: 'original_txn_id',
+        amount: 250,
+        currency: 'ZAR'
+      });
+
+      expect(result.provider).toBe('PEACH');
+      expect(result.status).toBe(PaymentStatus.CAPTURED);
+      expect(result.providerReference).toBe('capture_result_001');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/v1/payments/original_txn_id');
+      expect((callArgs.data as string)).toContain('paymentType=CP');
+      expect((callArgs.headers as Record<string, string>).Authorization).toContain('Bearer');
+    });
+
+    it('returns FAILED for unsuccessful capture', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'capture_fail_001',
+        result: { code: '800.100.100', description: 'Transaction declined' }
+      });
+
+      const result = await provider.capture({
+        transactionId: 'original_txn_id',
+        amount: 250,
+        currency: 'ZAR'
+      });
+
+      expect(result.status).toBe(PaymentStatus.FAILED);
+    });
+  });
+
+  describe('refund', () => {
+    it('calls Payments API with RF payment type', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'refund_result_001',
+        result: { code: '000.100.110', description: 'Success' }
+      });
+
+      const result = await provider.refund({
+        transactionId: 'original_txn_id',
+        amount: 100,
+        currency: 'ZAR'
+      });
+
+      expect(result.provider).toBe('PEACH');
+      expect(result.status).toBe(PaymentStatus.REFUNDED);
+      expect(result.providerReference).toBe('refund_result_001');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/payments/original_txn_id');
+      expect((callArgs.data as string)).toContain('paymentType=RF');
+    });
+  });
+
+  describe('void', () => {
+    it('calls card management API with RV payment type', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'reversal_result_001',
+        result: { code: '000.100.110', description: 'Success' }
+      });
+
+      const result = await provider.void({
+        transactionId: 'original_txn_id',
+        amount: 250,
+        currency: 'ZAR'
+      });
+
+      expect(result.provider).toBe('PEACH');
+      expect(result.status).toBe(PaymentStatus.VOIDED);
+      expect(result.providerReference).toBe('reversal_result_001');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/v1/payments/original_txn_id');
+      expect((callArgs.data as string)).toContain('paymentType=RV');
+    });
+  });
+
+  describe('lookupTransaction', () => {
+    it('queries status by merchantTransactionId derived from merchantReference', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'status_txn_001',
+        amount: '250.00',
+        currency: 'ZAR',
+        paymentType: 'DB',
+        result: { code: '000.100.110', description: 'Success' }
+      });
+
+      const result = await provider.lookupTransaction({
+        providerReference: 'checkout_id_123',
+        merchantReference: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      });
+
+      expect(result.status).toBe(PaymentStatus.CAPTURED);
+      expect(result.providerReference).toBe('status_txn_001');
+      expect(result.merchantReference).toBe('a1b2c3d4e5f67890');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('merchantTransactionId=a1b2c3d4e5f67890');
+    });
+  });
+
+  describe('webhook handling', () => {
+    it('verifies a valid checkout webhook signature', () => {
+      const { generatePeachSignature } = jest.requireActual('../../src/providers/peach/peach.signature');
+      const { env } = jest.requireActual('../../src/config/env');
+      const secretToken = env.peach.secretToken;
+      const params = { merchantTransactionId: 'test1234test5678', amount: '100.00', currency: 'ZAR' };
+      const signature = generatePeachSignature(params, secretToken);
+      const formBody = Object.entries({ ...params, signature })
+        .map(([k, v]: [string, string]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&');
+
+      expect(provider.verifyWebhookSignature(formBody, '')).toBe(true);
+    });
+
+    it('falls back to header signature verification when signature header is provided', () => {
+      const result = provider.verifyWebhookSignature('some_payload', 'invalid_sig');
+      expect(result).toBe(false);
+    });
+
+    it('parses a webhook and resolves the full payment ID', async () => {
+      // First create a payment to populate the mapping
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_wh1' });
+      await provider.payment({
+        paymentId: 'f6a7b8c9-d0e1-2345-fabc-456789012345',
+        amount: 100,
+        currency: 'ZAR'
+      });
+
+      const webhookPayload = {
+        merchantTransactionId: 'f6a7b8c9d0e12345',
+        id: 'peach_payment_result_001',
+        paymentType: 'DB',
+        result: { code: '000.100.110' }
+      };
+
+      const event = await provider.handleWebhook(webhookPayload);
+
+      expect(event).not.toBeNull();
+      expect(event!.merchantReference).toBe('f6a7b8c9-d0e1-2345-fabc-456789012345');
+      expect(event!.providerReference).toBe('peach_payment_result_001');
+      expect(event!.status).toBe(PaymentStatus.CAPTURED);
+    });
+  });
+});

--- a/tests/providers/peach.s2s-payment.test.ts
+++ b/tests/providers/peach.s2s-payment.test.ts
@@ -1,0 +1,306 @@
+import { PaymentStatus } from '../../src/domain/enums';
+import { PeachProvider } from '../../src/providers/peach/peach.provider';
+
+jest.mock('../../src/infrastructure/http.client', () => ({
+  requestWithRetry: jest.fn()
+}));
+
+import { requestWithRetry } from '../../src/infrastructure/http.client';
+
+const mockRequestWithRetry = requestWithRetry as jest.MockedFunction<typeof requestWithRetry>;
+
+describe('PeachProvider S2S 3DS Card Flow', () => {
+  let provider: PeachProvider;
+
+  beforeEach(() => {
+    provider = new PeachProvider();
+    mockRequestWithRetry.mockReset();
+  });
+
+  const cardMetadata = {
+    'card.number': '4111111111111111',
+    'card.holder': 'Jane Jones',
+    'card.expiryMonth': '05',
+    'card.expiryYear': '2034',
+    'card.cvv': '123'
+  };
+
+  describe('payment with S2S card details', () => {
+    it('routes to S2S flow when card details are in metadata', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_pay_001',
+        paymentType: 'DB',
+        paymentBrand: 'VISA',
+        amount: '100.00',
+        currency: 'ZAR',
+        result: { code: '000.100.110', description: 'Request successfully processed' }
+      });
+
+      const result = await provider.payment({
+        paymentId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+        amount: 100,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: cardMetadata
+      });
+
+      expect(result.provider).toBe('PEACH');
+      expect(result.status).toBe(PaymentStatus.CAPTURED);
+      expect(result.providerReference).toBe('peach_s2s_pay_001');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/v1/payments');
+      expect((callArgs.url as string)).not.toContain('/checkout');
+      expect((callArgs.data as string)).toContain('card.number=4111111111111111');
+      expect((callArgs.data as string)).toContain('paymentType=DB');
+      expect((callArgs.data as string)).toContain('paymentBrand=VISA');
+    });
+
+    it('returns PENDING_3DS with redirect URL for 3DS challenge', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_3ds_001',
+        paymentType: 'DB',
+        paymentBrand: 'VISA',
+        amount: '100.00',
+        currency: 'ZAR',
+        result: { code: '000.200.000', description: 'transaction pending' },
+        redirect: {
+          url: 'https://3ds-challenge.example.com/authenticate',
+          method: 'POST',
+          parameters: [
+            { name: 'PaReq', value: 'encoded-pareq-data' },
+            { name: 'TermUrl', value: 'https://merchant.example.com/peach/return' }
+          ]
+        }
+      });
+
+      const result = await provider.payment({
+        paymentId: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+        amount: 100,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: cardMetadata
+      });
+
+      expect(result.status).toBe(PaymentStatus.PENDING_3DS);
+      expect(result.redirectUrl).toBe('https://3ds-challenge.example.com/authenticate');
+      expect(result.providerReference).toBe('peach_s2s_3ds_001');
+
+      const rawResponse = result.rawResponse as Record<string, unknown>;
+      expect(rawResponse.flowType).toBe('SERVER_TO_SERVER');
+    });
+
+    it('falls back to Hosted Checkout when no card details are provided', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_fallback' });
+
+      const result = await provider.payment({
+        paymentId: 'c3d4e5f6-a7b8-9012-cdef-123456789012',
+        amount: 250,
+        currency: 'ZAR',
+        paymentMethod: 'VISA'
+      });
+
+      expect(result.status).toBe(PaymentStatus.PENDING);
+      expect(result.redirectUrl).toContain('checkoutId=checkout_fallback');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/checkout');
+    });
+
+    it('falls back to Hosted Checkout for non-card brands even with card metadata', async () => {
+      mockRequestWithRetry.mockResolvedValue({ id: 'checkout_eft' });
+
+      const result = await provider.payment({
+        paymentId: 'd4e5f6a7-b8c9-0123-def0-123456789ABC',
+        amount: 300,
+        currency: 'ZAR',
+        paymentMethod: 'PEACHEFT',
+        metadata: cardMetadata
+      });
+
+      expect(result.status).toBe(PaymentStatus.PENDING);
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/checkout');
+    });
+  });
+
+  describe('authorize with S2S card details', () => {
+    it('uses PA payment type for S2S card authorize', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_auth_001',
+        paymentType: 'PA',
+        paymentBrand: 'VISA',
+        amount: '500.00',
+        currency: 'ZAR',
+        result: { code: '000.100.110', description: 'Request successfully processed' }
+      });
+
+      const result = await provider.authorize({
+        paymentId: 'e5f6a7b8-c9d0-1234-ef01-23456789ABCD',
+        amount: 500,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: cardMetadata
+      });
+
+      expect(result.status).toBe(PaymentStatus.AUTHORIZED);
+      expect(result.providerReference).toBe('peach_s2s_auth_001');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/v1/payments');
+      expect((callArgs.data as string)).toContain('paymentType=PA');
+    });
+
+    it('returns PENDING_3DS for authorize with 3DS challenge', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_auth_3ds',
+        paymentType: 'PA',
+        paymentBrand: 'MASTER',
+        result: { code: '000.200.000', description: 'transaction pending' },
+        redirect: {
+          url: 'https://3ds.example.com/challenge',
+          method: 'POST',
+          parameters: [{ name: 'creq', value: 'challenge-request-data' }]
+        }
+      });
+
+      const result = await provider.authorize({
+        paymentId: 'f6a7b8c9-d0e1-2345-f012-3456789ABCDE',
+        amount: 750,
+        currency: 'ZAR',
+        paymentMethod: 'MASTER',
+        metadata: cardMetadata
+      });
+
+      expect(result.status).toBe(PaymentStatus.PENDING_3DS);
+      expect(result.redirectUrl).toBe('https://3ds.example.com/challenge');
+    });
+  });
+
+  describe('S2S 3DS parameters', () => {
+    it('includes 3DS browser data when provided', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_browser',
+        result: { code: '000.100.110', description: 'success' }
+      });
+
+      await provider.payment({
+        paymentId: 'a7b8c9d0-e1f2-3456-0123-456789ABCDEF',
+        amount: 200,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: {
+          ...cardMetadata,
+          'customer.browser.acceptHeader': 'text/html',
+          'customer.browser.language': 'en-US',
+          'customer.browser.screenHeight': '1080',
+          'customer.browser.screenWidth': '1920',
+          'customer.browser.timezone': '-120',
+          'customer.browser.userAgent': 'Mozilla/5.0',
+          'customer.browser.javaEnabled': 'false',
+          'customer.browser.javascriptEnabled': 'true',
+          'customer.ip': '192.168.1.1'
+        }
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      const data = callArgs.data as string;
+      expect(data).toContain('customer.browser.acceptHeader=text%2Fhtml');
+      expect(data).toContain('customer.browser.language=en-US');
+      expect(data).toContain('customer.browser.screenHeight=1080');
+      expect(data).toContain('customer.browser.screenWidth=1920');
+      expect(data).toContain('customer.browser.timezone=-120');
+      expect(data).toContain('customer.ip=192.168.1.1');
+    });
+
+    it('includes threeDSecure challenge indicator when provided', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_challenge',
+        result: { code: '000.100.110', description: 'success' }
+      });
+
+      await provider.payment({
+        paymentId: 'b8c9d0e1-f234-5678-1234-56789ABCDEF0',
+        amount: 150,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: {
+          ...cardMetadata,
+          'threeDSecure.challengeIndicator': '04',
+          'threeDSecure.exemptionFlag': '03'
+        }
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      const data = callArgs.data as string;
+      expect(data).toContain('threeDSecure.challengeIndicator=04');
+      expect(data).toContain('threeDSecure.exemptionFlag=03');
+    });
+
+    it('includes custom parameters in S2S request', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: 'peach_s2s_custom',
+        result: { code: '000.100.110', description: 'success' }
+      });
+
+      await provider.payment({
+        paymentId: 'c9d0e1f2-3456-7890-2345-6789ABCDEF01',
+        amount: 100,
+        currency: 'ZAR',
+        paymentMethod: 'VISA',
+        metadata: {
+          ...cardMetadata,
+          'customParameters[3DS2_enrolled]': 'true',
+          'customParameters[3DS2_flow]': 'challenge'
+        }
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      const data = callArgs.data as string;
+      expect(data).toContain('customParameters%5B3DS2_enrolled%5D=true');
+      expect(data).toContain('customParameters%5B3DS2_flow%5D=challenge');
+    });
+  });
+
+  describe('lookupTransaction for S2S payments', () => {
+    it('uses S2S status endpoint for long provider references', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        id: '8ac7a4a29d21e3c1019d26a8952111ac',
+        paymentType: 'PA',
+        paymentBrand: 'VISA',
+        amount: '92.00',
+        currency: 'EUR',
+        merchantTransactionId: 'a1b2c3d4e5f67890',
+        result: { code: '000.100.110', description: 'success' }
+      });
+
+      const result = await provider.lookupTransaction({
+        providerReference: '8ac7a4a29d21e3c1019d26a8952111ac'
+      });
+
+      expect(result.status).toBe(PaymentStatus.AUTHORIZED);
+      expect(result.providerReference).toBe('8ac7a4a29d21e3c1019d26a8952111ac');
+      expect(result.merchantReference).toBe('a1b2c3d4e5f67890');
+      expect(result.amountInCents).toBe(9200);
+      expect(result.currency).toBe('EUR');
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/v1/payments/8ac7a4a29d21e3c1019d26a8952111ac');
+    });
+
+    it('uses Checkout status for short references', async () => {
+      mockRequestWithRetry.mockResolvedValue({
+        merchantTransactionId: 'a1b2c3d4e5f67890',
+        result: { code: '000.000.000', description: 'success' },
+        payments: [{ paymentType: 'DB', result: { code: '000.000.000' } }]
+      });
+
+      await provider.lookupTransaction({
+        merchantReference: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+      });
+
+      const callArgs = mockRequestWithRetry.mock.calls[0][0] as Record<string, unknown>;
+      expect((callArgs.url as string)).toContain('/status');
+    });
+  });
+});

--- a/tests/providers/peach.signature.test.ts
+++ b/tests/providers/peach.signature.test.ts
@@ -1,0 +1,88 @@
+import { generatePeachSignature, verifyPeachCheckoutSignature } from '../../src/providers/peach/peach.signature';
+
+describe('Peach Signature', () => {
+  const secretToken = 'test_secret_token_abc123';
+
+  describe('generatePeachSignature', () => {
+    it('generates HMAC SHA256 from sorted key-value pairs', () => {
+      const params = {
+        currency: 'ZAR',
+        amount: '250.00',
+        'authentication.entityId': 'entity_123'
+      };
+
+      const signature = generatePeachSignature(params, secretToken);
+
+      expect(signature).toHaveLength(64);
+      expect(typeof signature).toBe('string');
+    });
+
+    it('produces the same signature regardless of input key order', () => {
+      const params1 = { b: '2', a: '1', c: '3' };
+      const params2 = { c: '3', a: '1', b: '2' };
+
+      expect(generatePeachSignature(params1, secretToken)).toBe(generatePeachSignature(params2, secretToken));
+    });
+
+    it('produces different signatures for different params', () => {
+      const params1 = { amount: '100.00', currency: 'ZAR' };
+      const params2 = { amount: '200.00', currency: 'ZAR' };
+
+      expect(generatePeachSignature(params1, secretToken)).not.toBe(generatePeachSignature(params2, secretToken));
+    });
+
+    it('produces different signatures for different secrets', () => {
+      const params = { amount: '100.00' };
+
+      const sig1 = generatePeachSignature(params, 'secret_a');
+      const sig2 = generatePeachSignature(params, 'secret_b');
+
+      expect(sig1).not.toBe(sig2);
+    });
+  });
+
+  describe('verifyPeachCheckoutSignature', () => {
+    it('verifies a valid form-encoded webhook body', () => {
+      const params = {
+        'authentication.entityId': 'entity_123',
+        amount: '250.00',
+        currency: 'ZAR',
+        merchantTransactionId: 'abc123def456gh78',
+        paymentType: 'DB'
+      };
+
+      const signature = generatePeachSignature(params, secretToken);
+      const formBody = Object.entries({ ...params, signature })
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&');
+
+      expect(verifyPeachCheckoutSignature(formBody, secretToken)).toBe(true);
+    });
+
+    it('rejects a tampered form body', () => {
+      const params = {
+        amount: '250.00',
+        currency: 'ZAR'
+      };
+
+      const signature = generatePeachSignature(params, secretToken);
+      const tampered = `amount=999.00&currency=ZAR&signature=${encodeURIComponent(signature)}`;
+
+      expect(verifyPeachCheckoutSignature(tampered, secretToken)).toBe(false);
+    });
+
+    it('returns false when no signature is present', () => {
+      const formBody = 'amount=250.00&currency=ZAR';
+
+      expect(verifyPeachCheckoutSignature(formBody, secretToken)).toBe(false);
+    });
+
+    it('returns false with wrong secret', () => {
+      const params = { amount: '100.00' };
+      const signature = generatePeachSignature(params, secretToken);
+      const formBody = `amount=100.00&signature=${encodeURIComponent(signature)}`;
+
+      expect(verifyPeachCheckoutSignature(formBody, 'wrong_secret')).toBe(false);
+    });
+  });
+});

--- a/tests/providers/peach.status.test.ts
+++ b/tests/providers/peach.status.test.ts
@@ -1,0 +1,20 @@
+import { mapPeachStatusWithType } from '../../src/providers/peach/peach.status';
+import { PaymentStatus } from '../../src/domain/enums';
+
+describe('mapPeachStatusWithType', () => {
+  it.each([
+    ['000.000.000', 'DB', PaymentStatus.CAPTURED],
+    ['000.100.110', 'DB', PaymentStatus.CAPTURED],
+    ['000.100.112', 'PA', PaymentStatus.AUTHORIZED],
+    ['000.100.110', 'RF', PaymentStatus.REFUNDED],
+    ['000.100.110', 'CP', PaymentStatus.CAPTURED],
+    ['000.100.110', 'RV', PaymentStatus.VOIDED],
+    ['000.200.000', 'DB', PaymentStatus.PENDING],
+    ['000.200.100', 'PA', PaymentStatus.PENDING],
+    ['800.100.100', 'DB', PaymentStatus.FAILED],
+    ['100.400.500', 'PA', PaymentStatus.FAILED],
+    ['', 'DB', PaymentStatus.UNKNOWN]
+  ])('maps result code %s with type %s to %s', (resultCode, paymentType, expected) => {
+    expect(mapPeachStatusWithType(resultCode, paymentType)).toBe(expected);
+  });
+});

--- a/tests/providers/peach.webhook.test.ts
+++ b/tests/providers/peach.webhook.test.ts
@@ -1,0 +1,102 @@
+import { parsePeachWebhook } from '../../src/providers/peach/peach.webhook';
+import { PaymentStatus } from '../../src/domain/enums';
+
+describe('parsePeachWebhook', () => {
+  const merchantTransactionIdMap = new Map<string, string>();
+
+  beforeEach(() => {
+    merchantTransactionIdMap.clear();
+    merchantTransactionIdMap.set('abc123def456gh78', 'full-uuid-payment-id-here');
+  });
+
+  it('parses a form-encoded webhook body', () => {
+    const body = 'merchantTransactionId=abc123def456gh78&id=peach_txn_001&paymentType=DB&result.code=000.100.110';
+
+    const event = parsePeachWebhook(body, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.merchantReference).toBe('full-uuid-payment-id-here');
+    expect(event!.providerReference).toBe('peach_txn_001');
+    expect(event!.status).toBe(PaymentStatus.CAPTURED);
+  });
+
+  it('parses a JSON webhook payload', () => {
+    const payload = {
+      merchantTransactionId: 'abc123def456gh78',
+      id: 'peach_txn_002',
+      paymentType: 'PA',
+      result: { code: '000.100.112', description: 'Request successfully processed' }
+    };
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.merchantReference).toBe('full-uuid-payment-id-here');
+    expect(event!.providerReference).toBe('peach_txn_002');
+    expect(event!.status).toBe(PaymentStatus.AUTHORIZED);
+  });
+
+  it('parses a JSON string webhook payload', () => {
+    const payload = JSON.stringify({
+      merchantTransactionId: 'abc123def456gh78',
+      id: 'peach_txn_003',
+      paymentType: 'RF',
+      result: { code: '000.100.110' }
+    });
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.status).toBe(PaymentStatus.REFUNDED);
+  });
+
+  it('returns null when merchantTransactionId is missing', () => {
+    const payload = { id: 'peach_txn_004', paymentType: 'DB' };
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).toBeNull();
+  });
+
+  it('falls back to merchantTransactionId when mapping is not found', () => {
+    const payload = {
+      merchantTransactionId: 'unknown_short_id',
+      id: 'peach_txn_005',
+      paymentType: 'DB',
+      result: { code: '000.100.110' }
+    };
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.merchantReference).toBe('unknown_short_id');
+  });
+
+  it('maps failed result codes to FAILED status', () => {
+    const payload = {
+      merchantTransactionId: 'abc123def456gh78',
+      id: 'peach_txn_006',
+      paymentType: 'DB',
+      result: { code: '800.100.100' }
+    };
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.status).toBe(PaymentStatus.FAILED);
+  });
+
+  it('maps pending result codes to PENDING status', () => {
+    const payload = {
+      merchantTransactionId: 'abc123def456gh78',
+      id: 'peach_txn_007',
+      paymentType: 'DB',
+      result: { code: '000.200.000' }
+    };
+
+    const event = parsePeachWebhook(payload, merchantTransactionIdMap);
+
+    expect(event).not.toBeNull();
+    expect(event!.status).toBe(PaymentStatus.PENDING);
+  });
+});

--- a/tests/services/payment.service.test.ts
+++ b/tests/services/payment.service.test.ts
@@ -188,3 +188,116 @@ describe('PaymentService provider operation failures', () => {
     });
   });
 });
+
+describe('PaymentService provider refresh on reads', () => {
+  it('refreshes provider state when fetching a payment by id', async () => {
+    const provider: PaymentProvider = {
+      payment: jest.fn(),
+      authorize: jest.fn(),
+      capture: jest.fn(),
+      refund: jest.fn(),
+      void: jest.fn(),
+      lookupTransaction: jest.fn().mockResolvedValue({
+        providerReference: 'payflex_order_1',
+        payuReference: 'payflex_order_1',
+        merchantReference: 'payment_read_1',
+        transactionState: 'Approved',
+        transactionType: 'ORDER',
+        status: PaymentStatus.CAPTURED,
+        amountInCents: 12000,
+        currency: 'ZAR',
+        resultCode: '200',
+        resultMessage: 'Approved'
+      }),
+      verifyWebhookSignature: jest.fn().mockReturnValue(true),
+      handleWebhook: jest.fn().mockResolvedValue(null)
+    };
+
+    const paymentRepository = new InMemoryPaymentRepository();
+    const paymentLogRepository = new InMemoryPaymentLogRepository();
+    const service = new PaymentService(
+      { [PaymentProviderName.PAYFLEX]: provider } as Record<PaymentProviderName, PaymentProvider>,
+      paymentRepository,
+      paymentLogRepository
+    );
+
+    await paymentRepository.create({
+      id: 'payment_read_1',
+      provider: PaymentProviderName.PAYFLEX,
+      amount: 120,
+      currency: 'ZAR',
+      status: PaymentStatus.PENDING,
+      providerReference: 'payflex_order_1',
+      idempotencyKey: 'idem-read-1',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+
+    const payment = await service.getPayment('payment_read_1', { 'x-request-id': 'req-1' });
+
+    expect(payment?.status).toBe(PaymentStatus.CAPTURED);
+    expect(provider.lookupTransaction).toHaveBeenCalledWith({
+      providerReference: 'payflex_order_1',
+      payuReference: 'payflex_order_1',
+      merchantReference: 'payment_read_1'
+    });
+
+    const logs = await paymentLogRepository.listByPaymentId('payment_read_1');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].request).toMatchObject({ operation: 'payment-read' });
+  });
+
+  it('refreshes provider state for payments returned by the transaction list', async () => {
+    const provider: PaymentProvider = {
+      payment: jest.fn(),
+      authorize: jest.fn(),
+      capture: jest.fn(),
+      refund: jest.fn(),
+      void: jest.fn(),
+      lookupTransaction: jest.fn().mockResolvedValue({
+        providerReference: 'payflex_order_2',
+        payuReference: 'payflex_order_2',
+        merchantReference: 'payment_read_2',
+        transactionState: 'Approved',
+        transactionType: 'ORDER',
+        status: PaymentStatus.CAPTURED,
+        amountInCents: 19900,
+        currency: 'ZAR',
+        resultCode: '200',
+        resultMessage: 'Approved'
+      }),
+      verifyWebhookSignature: jest.fn().mockReturnValue(true),
+      handleWebhook: jest.fn().mockResolvedValue(null)
+    };
+
+    const paymentRepository = new InMemoryPaymentRepository();
+    const paymentLogRepository = new InMemoryPaymentLogRepository();
+    const service = new PaymentService(
+      { [PaymentProviderName.PAYFLEX]: provider } as Record<PaymentProviderName, PaymentProvider>,
+      paymentRepository,
+      paymentLogRepository
+    );
+
+    await paymentRepository.create({
+      id: 'payment_read_2',
+      provider: PaymentProviderName.PAYFLEX,
+      amount: 199,
+      currency: 'ZAR',
+      status: PaymentStatus.PENDING,
+      providerReference: 'payflex_order_2',
+      idempotencyKey: 'idem-read-2',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    });
+
+    const payments = await service.listTransactions({ 'x-request-id': 'req-2' });
+
+    expect(payments).toHaveLength(1);
+    expect(payments[0].status).toBe(PaymentStatus.CAPTURED);
+    expect(provider.lookupTransaction).toHaveBeenCalledTimes(1);
+
+    const logs = await paymentLogRepository.listByPaymentId('payment_read_2');
+    expect(logs).toHaveLength(1);
+    expect(logs[0].request).toMatchObject({ operation: 'transactions-read' });
+  });
+});


### PR DESCRIPTION
Implements the Peach Payments provider adapter following the PayU reference pattern.

Closes #2

- PeachProvider: payment, authorize, capture, refund, void, webhook
- Webhook signature validation
- Provider registered in registry
- Peach credentials support in provider-config repository
- Integration tests
