### PR TITLE
Extract shared failed-payment finalization in PaymentService

### DIFF
--- a/src/services/payment.service.ts
+++ b/src/services/payment.service.ts
@@ -71,6 +71,13 @@ export class PaymentService {
     return this.executeInitialFlow('authorize', input, headers);
   }
 
+  private async markPaymentFailed(payment: Payment): Promise<void> {
+    ensureTransition(payment.status, PaymentStatus.FAILED);
+    payment.status = PaymentStatus.FAILED;
+    payment.updatedAt = new Date();
+    await this.paymentRepository.update(payment);
+  }
+
   private async executeInitialFlow(
     flow: 'payment' | 'authorize',
     input: CreatePaymentInput,
@@ -206,18 +213,12 @@ export class PaymentService {
           continue;
         }
 
-        ensureTransition(payment.status, PaymentStatus.FAILED);
-        payment.status = PaymentStatus.FAILED;
-        payment.updatedAt = new Date();
-        await this.paymentRepository.update(payment);
+        await this.markPaymentFailed(payment);
         throw error;
       }
     }
 
-    ensureTransition(payment.status, PaymentStatus.FAILED);
-    payment.status = PaymentStatus.FAILED;
-    payment.updatedAt = new Date();
-    await this.paymentRepository.update(payment);
+    await this.markPaymentFailed(payment);
 
     if (lastError instanceof Error) {
       throw lastError;


### PR DESCRIPTION
## Summary
Removes duplicate failed-payment finalization logic in PaymentService.

## Changes
- Added markPaymentFailed helper.
- Replaced duplicate failure transition/update blocks with helper usage.
- Preserved transition guards and persistence behavior.

Closes #11